### PR TITLE
fix: uncomment runtime stage in Dockerfile multi-stage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
     -o /bin/oci-sd-proxy \
     ./cmd/server
 
-#FROM gcr.io/distroless/static-debian12:nonroot
+FROM gcr.io/distroless/static-debian12:nonroot
 
 # Metadata labels
 LABEL org.opencontainers.image.title="oci-prometheus-sd-proxy" \


### PR DESCRIPTION
 ## Problem
  The runtime stage in the Dockerfile was commented out, causing a circular dependency error in the multi-stage build.

  ## Solution
  Uncommented the `FROM gcr.io/distroless/static-debian12:nonroot` line to properly define the runtime stage.

  ## Testing
  Docker build pipeline will now succeed and images will be pushed to GHCR.