### PR TITLE
Chore/fix prometheus docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,23 @@ scrape_configs:
         authorization:
           type: Bearer
           credentials: 'YOUR_TOKEN'
+        refresh_interval: 60s
+    scrape_interval: 30s
+    scrape_timeout: 10s
+    metrics_path: /metrics
     relabel_configs:
       - source_labels: [__meta_oci_instance_name]
         target_label: instance
       - source_labels: [__meta_oci_tenancy_name]
         target_label: tenancy
+      - source_labels: [__meta_oci_compartment_name]
+        target_label: compartment
+      - source_labels: [__meta_oci_region]
+        target_label: region
+      - source_labels: [__meta_oci_availability_domain]
+        target_label: availability_domain
+      - source_labels: [__meta_oci_instance_shape]
+        target_label: shape
 ```
 
 ## Full Documentation

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,8 +3,8 @@
 project = "oci-prometheus-sd-proxy"
 copyright = "2026, Amaan Ul Haq Siddiqui"
 author = "Amaan Ul Haq Siddiqui"
-version = "1.0"
-release = "1.0.0"
+version = "1.1"
+release = "1.1.0"
 
 extensions = [
     "myst_parser",  # Markdown support

--- a/docs/prometheus-setup.rst
+++ b/docs/prometheus-setup.rst
@@ -15,6 +15,10 @@ Add HTTP SD configuration to your ``prometheus.yml``:
             authorization:
               type: Bearer
               credentials: 'YOUR_SERVER_TOKEN'
+            refresh_interval: 60s
+        scrape_interval: 30s
+        scrape_timeout: 10s
+        metrics_path: /metrics
 
 Relabeling
 ----------
@@ -37,11 +41,11 @@ Map OCI metadata to Prometheus labels:
         target_label: region
 
       # Compartment
-      - source_labels: [__meta_oci_compartment_id]
+      - source_labels: [__meta_oci_compartment_name]
         target_label: compartment
 
       # Shape
-      - source_labels: [__meta_oci_shape]
+      - source_labels: [__meta_oci_instance_shape]
         target_label: shape
 
       # Availability domain
@@ -56,11 +60,12 @@ All discovered instances include these labels:
 - ``__meta_oci_instance_name`` - Instance name
 - ``__meta_oci_instance_id`` - Instance OCID
 - ``__meta_oci_instance_state`` - RUNNING, STOPPED, etc.
+- ``__meta_oci_instance_shape`` - Instance shape (e.g., VM.Standard.E6.Flex)
 - ``__meta_oci_tenancy_name`` - Tenancy name
 - ``__meta_oci_tenancy_id`` - Tenancy OCID
 - ``__meta_oci_region`` - OCI region
+- ``__meta_oci_compartment_name`` - Compartment name
 - ``__meta_oci_compartment_id`` - Compartment OCID
-- ``__meta_oci_shape`` - Instance shape (e.g., VM.Standard.E6.Flex)
 - ``__meta_oci_availability_domain`` - AD name
 - ``__meta_oci_fault_domain`` - Fault domain
 - ``__meta_oci_image_id`` - Image OCID


### PR DESCRIPTION
This pull request updates the documentation for configuring Prometheus with the OCI Prometheus SD Proxy. The main focus is on improving the example configurations, clarifying label mappings, and updating version information. The changes ensure that users have clearer guidance and more accurate label mapping for OCI resources.

**Prometheus configuration improvements:**

* Added `refresh_interval`, `scrape_interval`, `scrape_timeout`, and `metrics_path` to the HTTP SD and scrape configuration examples in both `README.md` and `docs/prometheus-setup.rst` for more complete and robust Prometheus setup instructions. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R51-R67) [[2]](diffhunk://#diff-ff40d583d12917175889c2bb2be6de5bb6758bb929ecc52c184d4c7f6fd28179R18-R21)

**Label mapping and documentation updates:**

* Updated relabeling examples to use `__meta_oci_compartment_name` and `__meta_oci_instance_shape` instead of `__meta_oci_compartment_id` and `__meta_oci_shape`, and included new mappings for `region`, `availability_domain`, and `shape` for improved label clarity. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R51-R67) [[2]](diffhunk://#diff-ff40d583d12917175889c2bb2be6de5bb6758bb929ecc52c184d4c7f6fd28179L40-R48)
* Updated the list of discovered instance labels to include `__meta_oci_instance_shape` and `__meta_oci_compartment_name`, and removed the deprecated `__meta_oci_shape` label.

**Version bump:**

* Bumped the documentation version from 1.0.0 to 1.1.0 in `docs/conf.py` to reflect these updates.## Description

Brief summary of changes and context. Link any related issues.

Fixes #(issue)

## Type of Change

- [ ] Bug fix (non-breaking)
- [ ] Feature (non-breaking)
- [ ] Breaking change
- [✓] Documentation update

## Testing

- [✓] `make test` passes
- [ ] Manual testing completed

**Test details:**
- Go version:
- Test environment: (local, Docker, etc.)

## Checklist

- [✓] `make lint` passes
- [✓] Self-review completed
- [✓] Comments added for complex logic
- [✓] Documentation updated
- [✓] Tests added or updated
- [✓] All CI checks pass
