### PR TITLE
feat: canonical refresh log line with cycle ID, targets delta, and transition-only tenancy alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0] - 2026-03-21
+
+### Added
+
+- **Canonical refresh log line**: Single `target_refresh_complete` log line per cycle with `cycle_id`, `duration_ms`, `total_groups`, `had_errors`, `tenancies_total`, `tenancies_with_errors`, `compartments_discovered`, `compartments_failed`, `error_tenancies`, `targets_added`, `targets_removed`, `targets_unchanged`
+- **Targets delta tracking**: Each refresh cycle reports how many targets were added, removed, or unchanged compared to the previous cycle, making silent target loss visible
+- **Cycle ID**: Monotonic `cycle_id` field on all refresh-related log lines for correlation across sub-logs
+- **Tenancy state transition logging**: `tenancy_discovery_complete` WARN fires only on healthy-to-degraded transition; INFO fires on recovery - persistent failures produce no repeated noise
+
+### Changed
+
+- `target_refresh_complete` emits at WARN level when `had_errors=true`, INFO otherwise - enables log-level-based alerting without custom field matchers
+- Per-compartment `failed to list child compartments` log demoted from WARN to DEBUG - eliminates ~11,500 redundant log lines/day for persistent IAM failures
+- `refreshStats` struct introduced to accumulate per-cycle metrics across all tenancies
+
+### Fixed
+
+- `had_errors=false` on `target_refresh_complete` when compartment-level failures occurred in the same cycle - propagation now flows correctly from compartment stats through tenancy stats to the cycle summary
+- `targets_removed` falsely reported when all tenancies fail and stale cache is retained - delta now reflects what was actually committed to cache, not the theoretical diff
+- Network and TLS errors now classified as `error_code: network_error` instead of `unknown` - `*url.Error` (wraps TLS, DNS, HTTP transport failures) and `*net.OpError` are both detected; context cancellations and deadlines classified as `context_canceled` and `timeout` respectively
+- OCI service error codes (e.g. `NotAuthorizedOrNotFound`) now correctly extracted when wrapped - `extractErrorCode` walks the full error chain instead of using a direct type assertion, fixing cases where the SDK wraps the underlying `servicefailure` type
+
 ## [1.1.0] - 2026-03-10
 
 ### Added
@@ -117,6 +139,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - GitHub Actions CI/CD for testing and Docker image building
   - CodeQL security scanning
 
-[Unreleased]: https://github.com/amaanx86/oci-prometheus-sd-proxy/compare/v1.1.0...HEAD
+[Unreleased]: https://github.com/amaanx86/oci-prometheus-sd-proxy/compare/v1.2.0...HEAD
+[1.2.0]: https://github.com/amaanx86/oci-prometheus-sd-proxy/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/amaanx86/oci-prometheus-sd-proxy/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/amaanx86/oci-prometheus-sd-proxy/releases/tag/v1.0.0

--- a/internal/discovery/cache.go
+++ b/internal/discovery/cache.go
@@ -14,15 +14,22 @@ import (
 // in the background at the configured interval. HTTP handlers call Get()
 // which always returns instantly from memory.
 type Cache struct {
-	cfg     *config.Config
-	mu      sync.RWMutex
-	targets []TargetGroup
-	lastErr error
+	cfg              *config.Config
+	mu               sync.RWMutex
+	targets          []TargetGroup
+	lastErr          error
+	prevTargetSet    map[string]struct{}
+	failingTenancies map[string]bool
+	cycleSeq         int64
 }
 
 // NewCache creates a Cache; call Start to begin background refresh.
 func NewCache(cfg *config.Config) *Cache {
-	return &Cache{cfg: cfg}
+	return &Cache{
+		cfg:              cfg,
+		prevTargetSet:    make(map[string]struct{}),
+		failingTenancies: make(map[string]bool),
+	}
 }
 
 // Start performs an initial synchronous refresh (so the server starts with data)
@@ -66,15 +73,28 @@ func (c *Cache) LastError() error {
 	return c.lastErr
 }
 
+// refreshStats accumulates per-cycle metrics across all tenancies.
+type refreshStats struct {
+	tenanciesTotal      int
+	tenanciesWithErrors int
+	compartmentsFound   int
+	compartmentsFailed  int
+	errorTenancies      []string
+}
+
 // refresh discovers targets from all configured tenancies concurrently.
 // A failure in one tenancy logs an error but does not prevent others from
 // completing - the last successful full result is retained on partial failure.
 func (c *Cache) refresh(ctx context.Context) {
-	slog.Info("starting target refresh")
+	c.cycleSeq++
+	cycleID := c.cycleSeq
+
+	slog.Info("starting target refresh", "cycle_id", cycleID)
 	start := time.Now()
 
 	type result struct {
 		groups []TargetGroup
+		stats  tenancyStats
 		err    error
 		name   string
 	}
@@ -83,8 +103,8 @@ func (c *Cache) refresh(ctx context.Context) {
 
 	for _, tenancy := range c.cfg.Tenancies {
 		go func(t config.TenancyConfig) {
-			groups, err := discoverTenancy(ctx, c.cfg, t)
-			results <- result{groups: groups, err: err, name: t.Name}
+			groups, stats, err := discoverTenancy(ctx, c.cfg, t)
+			results <- result{groups: groups, stats: stats, err: err, name: t.Name}
 		}(tenancy)
 	}
 
@@ -93,39 +113,135 @@ func (c *Cache) refresh(ctx context.Context) {
 		anyError bool
 	)
 
+	rs := refreshStats{
+		tenanciesTotal: len(c.cfg.Tenancies),
+		errorTenancies: []string{},
+	}
+
+	// nowFailing tracks which tenancies degraded this cycle for transition detection.
+	nowFailing := make(map[string]bool)
+
 	for range c.cfg.Tenancies {
 		r := <-results
 		if r.err != nil {
 			slog.Error("tenancy discovery failed",
+				"cycle_id", cycleID,
 				"tenancy", r.name,
 				"error", r.err,
 			)
 			anyError = true
+			rs.tenanciesWithErrors++
+			rs.errorTenancies = append(rs.errorTenancies, r.name)
+			nowFailing[r.name] = true
 			continue
 		}
-		slog.Info("tenancy discovery complete",
-			"tenancy", r.name,
-			"target_groups", len(r.groups),
-		)
+
+		rs.compartmentsFound += r.stats.compartmentsDiscovered
+		rs.compartmentsFailed += r.stats.compartmentsFailed
+
+		if r.stats.hadErrors {
+			anyError = true
+			rs.tenanciesWithErrors++
+			rs.errorTenancies = append(rs.errorTenancies, r.name)
+			nowFailing[r.name] = true
+
+			// Emit WARN only on transition: healthy -> degraded.
+			// Persistent failures on every cycle produce no additional signal.
+			if !c.failingTenancies[r.name] {
+				slog.Warn("tenancy_discovery_complete",
+					"cycle_id", cycleID,
+					"tenancy", r.name,
+					"compartments_ok", r.stats.compartmentsDiscovered,
+					"compartments_failed", r.stats.compartmentsFailed,
+					"error_code", r.stats.errorCode,
+					"state", "degraded",
+				)
+			}
+		} else if c.failingTenancies[r.name] {
+			// Emit INFO on recovery: degraded -> healthy.
+			slog.Info("tenancy_discovery_complete",
+				"cycle_id", cycleID,
+				"tenancy", r.name,
+				"compartments_ok", r.stats.compartmentsDiscovered,
+				"compartments_failed", 0,
+				"state", "recovered",
+			)
+		}
+
 		all = append(all, r.groups...)
 	}
+
+	// Update per-tenancy failure state for next cycle's transition check.
+	c.failingTenancies = nowFailing
 
 	var refreshErr error
 	if anyError {
 		refreshErr = fmt.Errorf("one or more tenancies failed during refresh")
 	}
 
-	// Only update the cache when at least some results came back
+	// Compute targets delta only when the cache is actually updated.
+	// If all tenancies failed we retain stale data, so the delta from Prometheus'
+	// perspective is zero — logging targets_removed would be misleading.
+	var added, removed, unchanged int
 	if len(all) > 0 || !anyError {
+		currentSet := targetSet(all)
+		added, removed, unchanged = computeDelta(c.prevTargetSet, currentSet)
 		c.mu.Lock()
 		c.targets = all
 		c.lastErr = refreshErr
 		c.mu.Unlock()
+		c.prevTargetSet = currentSet
+	} else {
+		unchanged = len(c.prevTargetSet)
 	}
 
-	slog.Info("target refresh complete",
-		"total_groups", len(all),
+	// Use WARN when the cycle had any errors so alerting rules can match on level.
+	logFn := slog.Info
+	if anyError {
+		logFn = slog.Warn
+	}
+
+	logFn("target_refresh_complete",
+		"cycle_id", cycleID,
 		"duration_ms", time.Since(start).Milliseconds(),
+		"total_groups", len(all),
 		"had_errors", anyError,
+		"tenancies_total", rs.tenanciesTotal,
+		"tenancies_with_errors", rs.tenanciesWithErrors,
+		"compartments_discovered", rs.compartmentsFound,
+		"compartments_failed", rs.compartmentsFailed,
+		"error_tenancies", rs.errorTenancies,
+		"targets_added", added,
+		"targets_removed", removed,
+		"targets_unchanged", unchanged,
 	)
+}
+
+// targetSet builds a flat set of all target addresses across all groups.
+func targetSet(groups []TargetGroup) map[string]struct{} {
+	s := make(map[string]struct{}, len(groups))
+	for _, g := range groups {
+		for _, t := range g.Targets {
+			s[t] = struct{}{}
+		}
+	}
+	return s
+}
+
+// computeDelta returns counts of added, removed, and unchanged targets
+// between the previous and current target sets.
+func computeDelta(prev, curr map[string]struct{}) (added, removed, unchanged int) {
+	for t := range curr {
+		if _, ok := prev[t]; ok {
+			unchanged++
+		} else {
+			added++
+		}
+	}
+	for t := range prev {
+		if _, ok := curr[t]; !ok {
+			removed++
+		}
+	}
+	return
 }

--- a/internal/discovery/oci.go
+++ b/internal/discovery/oci.go
@@ -414,8 +414,12 @@ func buildLabels(
 // Non-service errors are classified by type so alerting rules can match specific
 // failure modes rather than the catch-all "unknown".
 func extractErrorCode(err error) string {
-	if svcErr, ok := common.IsServiceError(err); ok {
-		return svcErr.GetCode()
+	// IsServiceError uses a direct type assertion so it misses wrapped errors.
+	// Walk the chain manually to handle any SDK wrapping.
+	for e := err; e != nil; e = errors.Unwrap(e) {
+		if svcErr, ok := common.IsServiceError(e); ok {
+			return svcErr.GetCode()
+		}
 	}
 	if errors.Is(err, context.Canceled) {
 		return "context_canceled"

--- a/internal/discovery/oci.go
+++ b/internal/discovery/oci.go
@@ -2,8 +2,11 @@ package discovery
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
+	"net"
+	"net/url"
 	"os"
 	"strings"
 
@@ -14,6 +17,14 @@ import (
 
 	"github.com/amaanx86/oci-prometheus-sd-proxy/internal/config"
 )
+
+// tenancyStats holds compartment-level discovery metrics for a single tenancy refresh.
+type tenancyStats struct {
+	compartmentsDiscovered int
+	compartmentsFailed     int
+	hadErrors              bool
+	errorCode              string
+}
 
 // tenancyDiscoverer holds shared state for discovering a single tenancy.
 type tenancyDiscoverer struct {
@@ -29,10 +40,10 @@ type tenancyDiscoverer struct {
 // discoverTenancy returns all matching target groups from a single OCI tenancy.
 // Errors from individual compartments are logged and skipped rather than failing
 // the entire tenancy, so a partial result is always returned.
-func discoverTenancy(ctx context.Context, cfg *config.Config, tenancy config.TenancyConfig) ([]TargetGroup, error) {
+func discoverTenancy(ctx context.Context, cfg *config.Config, tenancy config.TenancyConfig) ([]TargetGroup, tenancyStats, error) {
 	keyContent, err := os.ReadFile(tenancy.PrivateKeyPath)
 	if err != nil {
-		return nil, fmt.Errorf("read private key for tenancy %q: %w", tenancy.Name, err)
+		return nil, tenancyStats{}, fmt.Errorf("read private key for tenancy %q: %w", tenancy.Name, err)
 	}
 
 	var passphrase *string
@@ -51,17 +62,17 @@ func discoverTenancy(ctx context.Context, cfg *config.Config, tenancy config.Ten
 
 	computeClient, err := core.NewComputeClientWithConfigurationProvider(provider)
 	if err != nil {
-		return nil, fmt.Errorf("create compute client for tenancy %q: %w", tenancy.Name, err)
+		return nil, tenancyStats{}, fmt.Errorf("create compute client for tenancy %q: %w", tenancy.Name, err)
 	}
 
 	netClient, err := core.NewVirtualNetworkClientWithConfigurationProvider(provider)
 	if err != nil {
-		return nil, fmt.Errorf("create network client for tenancy %q: %w", tenancy.Name, err)
+		return nil, tenancyStats{}, fmt.Errorf("create network client for tenancy %q: %w", tenancy.Name, err)
 	}
 
 	identityClient, err := identity.NewIdentityClientWithConfigurationProvider(provider)
 	if err != nil {
-		return nil, fmt.Errorf("create identity client for tenancy %q: %w", tenancy.Name, err)
+		return nil, tenancyStats{}, fmt.Errorf("create identity client for tenancy %q: %w", tenancy.Name, err)
 	}
 
 	// Create rate limiter with burst equal to burst for this tenancy
@@ -87,7 +98,7 @@ func discoverTenancy(ctx context.Context, cfg *config.Config, tenancy config.Ten
 
 // discover is the main entry point for the tenancyDiscoverer, orchestrating
 // compartment discovery and target group discovery.
-func (d *tenancyDiscoverer) discover(ctx context.Context) ([]TargetGroup, error) {
+func (d *tenancyDiscoverer) discover(ctx context.Context) ([]TargetGroup, tenancyStats, error) {
 	// Determine which compartments to scan
 	compartmentsToScan := d.tenancy.Compartments
 
@@ -110,20 +121,34 @@ func (d *tenancyDiscoverer) discover(ctx context.Context) ([]TargetGroup, error)
 		}
 	}
 
-	var groups []TargetGroup
+	var (
+		groups []TargetGroup
+		stats  tenancyStats
+	)
+
 	for _, compartmentID := range compartmentsToScan {
 		cGroups, err := d.discoverCompartment(ctx, compartmentID)
 		if err != nil {
-			slog.Warn("compartment discovery failed - skipping",
+			slog.Debug("compartment discovery failed - skipping",
 				"tenancy", d.tenancy.Name,
 				"compartment_id", compartmentID,
 				"error", err,
 			)
+			if stats.errorCode == "" {
+				stats.errorCode = extractErrorCode(err)
+			}
+			stats.compartmentsFailed++
 			continue
 		}
+		stats.compartmentsDiscovered++
 		groups = append(groups, cGroups...)
 	}
-	return groups, nil
+
+	if stats.compartmentsFailed > 0 {
+		stats.hadErrors = true
+	}
+
+	return groups, stats, nil
 }
 
 // discoverCompartment lists all running instances in a compartment that match
@@ -233,7 +258,7 @@ func (d *tenancyDiscoverer) listAllCompartments(ctx context.Context, rootCompart
 				},
 			})
 			if err != nil {
-				slog.Warn("failed to list child compartments",
+				slog.Debug("failed to list child compartments",
 					"parent_compartment_id", current,
 					"error", err,
 				)
@@ -382,6 +407,31 @@ func buildLabels(
 	}
 
 	return labels
+}
+
+// extractErrorCode classifies an error into a loggable code.
+// OCI service errors return their HTTP error code (e.g. NotAuthorizedOrNotFound).
+// Non-service errors are classified by type so alerting rules can match specific
+// failure modes rather than the catch-all "unknown".
+func extractErrorCode(err error) string {
+	if svcErr, ok := common.IsServiceError(err); ok {
+		return svcErr.GetCode()
+	}
+	if errors.Is(err, context.Canceled) {
+		return "context_canceled"
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return "timeout"
+	}
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) {
+		return "network_error"
+	}
+	var netErr *net.OpError
+	if errors.As(err, &netErr) {
+		return "network_error"
+	}
+	return "unknown"
 }
 
 // sanitizeLabelKey converts an arbitrary string to a valid Prometheus label key


### PR DESCRIPTION
## Description

Implements canonical log line for the target refresh cycle and resolves all observability issues described in #12.

Closes #12

## Type of Change

- [x] Bug fix (non-breaking)
- [x] Feature (non-breaking)
- [ ] Breaking change
- [ ] Documentation update

## Changes

**`internal/discovery/cache.go`**
- Adds monotonic `cycle_id` to correlate all refresh sub-logs to a single cycle
- Introduces `refreshStats` to accumulate per-cycle metrics across tenancies
- Emits single canonical `target_refresh_complete` log line with `duration_ms`, `total_groups`, `had_errors`, `tenancies_total`, `tenancies_with_errors`, `compartments_discovered`, `compartments_failed`, `error_tenancies`, `targets_added`, `targets_removed`, `targets_unchanged`
- Fixes `had_errors=false` bug — correctly propagates compartment-level failures up to the cycle summary
- Tracks `prevTargetSet` for targets delta; skips delta update when stale cache is retained (prevents false `targets_removed` on full outage)
- Emits `tenancy_discovery_complete` WARN only on healthy→degraded transition; INFO on recovery — persistent failures produce no repeated noise

**`internal/discovery/oci.go`**
- Demotes per-compartment `failed to list child compartments` from WARN to DEBUG (~11,500 redundant log lines/day eliminated)
- Improves `extractErrorCode` to walk the full error chain (fixes `error_code: unknown` for wrapped OCI service errors — now correctly surfaces `NotAuthorizedOrNotFound`)
- Adds `*url.Error` detection for TLS/DNS/HTTP transport failures (`network_error`), `context.Canceled`, and `context.DeadlineExceeded`
- Removes per-tenancy WARN from `discover()` — state transition logic now handled in cache

**`CHANGELOG.md`** — updated for v1.2.0

## Testing

- [x] `make test` passes
- [x] Manual testing completed

**Test details:**
- Go version: 1.22
- Test environment: Docker (local), validated against 18 OCI tenancies
- Verified `had_errors=true` with 4 failing tenancies
- Verified `error_code: NotAuthorizedOrNotFound` (was `unknown`)
- Verified `error_code: network_error` under VPN with self-signed TLS cert
- Verified transition-only WARNs: 14 new degraded on full TLS outage (not 18 — 4 already-failing excluded)
- Verified `targets_unchanged: 116` when stale cache retained (was `targets_removed: 116`)
- Verified `state: recovered` INFO on restoration

## Checklist

- [x] `make lint` passes
- [x] Self-review completed
- [x] Comments added for complex logic
- [x] Documentation updated
- [x] All CI checks pass