### PR TITLE
docs: add OCI IAM policy requirements for service discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **OCI IAM policy documentation**: Added required IAM policy statements to README and `docs/installation.rst` covering all five API call families (`read instances`, `read compartments`, `read vnic-attachments`, `read vnics`, `read tag-namespaces`) with per-call mapping table and note on `NotAuthorizedOrNotFound` behavior
+
 - **Canonical refresh log line**: Single `target_refresh_complete` log line per cycle with `cycle_id`, `duration_ms`, `total_groups`, `had_errors`, `tenancies_total`, `tenancies_with_errors`, `compartments_discovered`, `compartments_failed`, `error_tenancies`, `targets_added`, `targets_removed`, `targets_unchanged`
 - **Targets delta tracking**: Each refresh cycle reports how many targets were added, removed, or unchanged compared to the previous cycle, making silent target loss visible
 - **Cycle ID**: Monotonic `cycle_id` field on all refresh-related log lines for correlation across sub-logs

--- a/README.md
+++ b/README.md
@@ -67,6 +67,20 @@ scrape_configs:
         target_label: shape
 ```
 
+## OCI IAM Policy
+
+The OCI user or group used by this service requires the following IAM policies in each tenancy:
+
+```
+Allow group <group-name> to read instances in tenancy
+Allow group <group-name> to read compartments in tenancy
+Allow group <group-name> to read vnic-attachments in tenancy
+Allow group <group-name> to read vnics in tenancy
+Allow group <group-name> to read tag-namespaces in tenancy
+```
+
+Replace `<group-name>` with the OCI group that contains the API key user. These policies cover compartment auto-discovery, instance listing, VNIC resolution, and tag-based filtering. Missing any of these will result in `NotAuthorizedOrNotFound` errors in the logs.
+
 ## Full Documentation
 
 Complete documentation available at: **https://oci-prometheus-sd-proxy.readthedocs.io/**

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -59,10 +59,45 @@ Before running the service:
 
 2. **Create API credentials** for each OCI tenancy:
 
-   - Generate API key pair
-   - User must have permissions:
-     - ``inspect instance-family`` on all compartments
-     - ``inspect virtual-network-family`` on all compartments
+   - Generate an API key pair in OCI Console under **Identity > Users > API Keys**
+   - Add the user to an OCI group and attach the following IAM policies to that group in each tenancy:
+
+   .. code-block:: text
+
+       Allow group <group-name> to read instances in tenancy
+       Allow group <group-name> to read compartments in tenancy
+       Allow group <group-name> to read vnic-attachments in tenancy
+       Allow group <group-name> to read vnics in tenancy
+       Allow group <group-name> to read tag-namespaces in tenancy
+
+   Replace ``<group-name>`` with the OCI group containing your API key user. These five policies cover all API calls the proxy makes:
+
+   .. list-table::
+      :header-rows: 1
+      :widths: 20 30 30
+
+      * - OCI Service
+        - API Call
+        - Policy Required
+      * - Identity
+        - ``ListCompartments``
+        - ``read compartments``
+      * - Compute
+        - ``ListInstances``
+        - ``read instances``
+      * - Compute
+        - ``ListVnicAttachments``
+        - ``read vnic-attachments``
+      * - Networking
+        - ``GetVnic``
+        - ``read vnics``
+      * - Tagging
+        - Tag-based filtering
+        - ``read tag-namespaces``
+
+   .. note::
+
+      Missing any of these policies will cause ``NotAuthorizedOrNotFound`` errors in the logs for the affected compartments. The proxy will continue serving other tenancies and retain stale targets for the affected ones.
 
 3. **Prepare configuration file**:
 


### PR DESCRIPTION
## Description

Documents the required OCI IAM policies for the proxy to function. Users hitting `NotAuthorizedOrNotFound` on all compartments had no guidance on what to configure.

Closes #14

## Type of Change

- [ ] Bug fix (non-breaking)
- [ ] Feature (non-breaking)
- [ ] Breaking change
- [x] Documentation update

## Changes

- **README.md** — added `OCI IAM Policy` section with the five required policy statements and a note on `NotAuthorizedOrNotFound` behavior
- **docs/installation.rst** — replaced incomplete `inspect instance-family` / `inspect virtual-network-family` with the correct `read` verb policies, added API call mapping table, and a note on partial failure behavior
- **CHANGELOG.md** — updated v1.2.0 entry

## Testing

- [x] Manual testing completed — policies validated against live tenancies

## Checklist

- [x] Self-review completed
- [x] Documentation updated
- [x] All CI checks pass