### PR TITLE
ci: skip go-test on docs and markdown changes

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -3,8 +3,18 @@ name: Go Test & Lint
 on:
   pull_request:
     branches: [main]
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
+      - '**.rst'
+      - '**.txt'
   push:
     branches: [main]
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
+      - '**.rst'
+      - '**.txt'
 
 jobs:
   test:


### PR DESCRIPTION
## Description

Add `paths-ignore` filters to the Go Test & Lint workflow so it does not run when only documentation files are changed.

Ignored paths:
- `docs/**`
- `**.md`
- `**.rst`
- `**.txt`

## Type of Change

- [x] Documentation update

## Testing

- [x] `make test` passes
- [x] Manual testing completed

**Test details:**
- Go version: N/A
- Test environment: local

## Checklist

- [x] `make lint` passes
- [x] Self-review completed
- [ ] Comments added for complex logic
- [x] Documentation updated
- [ ] Tests added or updated
- [x] All CI checks pass
