### PR TITLE
test: add comprehensive test suite and document testing policy

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,8 +13,11 @@ Fixes #(issue)
 
 ## Testing
 
-- [ ] `make test` passes
-- [ ] Manual testing completed
+**New or changed functionality requires automated tests** (see [CONTRIBUTING.md](../CONTRIBUTING.md#testing)).
+
+- [ ] `make test` passes (`go test -race -cover ./...`)
+- [ ] New/changed code has corresponding test cases in `*_test.go`
+- [ ] If OCI-calling code was changed, manual integration testing completed
 
 **Test details:**
 - Go version:
@@ -25,6 +28,6 @@ Fixes #(issue)
 - [ ] `make lint` passes
 - [ ] Self-review completed
 - [ ] Comments added for complex logic
-- [ ] Documentation updated
-- [ ] Tests added or updated
+- [ ] Documentation updated (CONTRIBUTING.md, README if needed)
+- [ ] Tests added or updated for all new functionality
 - [ ] All CI checks pass

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,11 +60,49 @@ git config commit.gpgsign true
 
 ## Testing
 
-All new features must include tests:
+**Policy: all new functionality and bug fixes must include automated tests.**
+This requirement applies to every pull request - PRs that add code without
+corresponding tests will not be merged.
+
+Run the full test suite (with race detector and coverage):
 
 ```bash
 make test
+# equivalent to: go test -race -cover ./...
 ```
+
+Run a single package:
+
+```bash
+go test -race -run TestFunctionName ./internal/discovery/
+```
+
+### What to test
+
+| Area | Location | Notes |
+|------|----------|-------|
+| Config loading and validation | `internal/config/` | Table-driven, use `t.TempDir()` for temp files |
+| Middleware (auth, logging) | `internal/middleware/` | Use `httptest.NewRequest` / `httptest.NewRecorder` |
+| HTTP handler | `internal/handler/` | Mock `TargetCache` interface |
+| Discovery pure functions | `internal/discovery/` | `hasTag`, `isWindows`, `buildLabels`, `sanitizeLabelKey`, `extractErrorCode` |
+| Cache utilities | `internal/discovery/` | `targetSet`, `computeDelta`, `Get`, `LastError` |
+| Server routing | `internal/server/` | Use `httptest.NewServer` |
+
+OCI API-calling methods (`discoverTenancy`, `discover`, `discoverCompartment`,
+`listAllInstances`, `listAllCompartments`, `getPrimaryPrivateIP`) require live
+OCI credentials and are excluded from unit testing. Integration tests for these
+functions belong in a separate `_integration_test.go` file and are skipped by
+default with a build tag.
+
+### Coverage
+
+We target >= 60% statement coverage overall. The hard floor per package is:
+
+- `internal/config` - 90%+
+- `internal/middleware` - 100%
+- `internal/handler` - 100%
+- `internal/server` - 100%
+- `internal/discovery` - 40%+ (limited by OCI SDK boundary)
 
 ## Building
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,365 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// writeConfigFile writes content to a temp file and returns the path.
+func writeConfigFile(t *testing.T, content string) string {
+	t.Helper()
+	f, err := os.CreateTemp(t.TempDir(), "config-*.yaml")
+	if err != nil {
+		t.Fatalf("create temp file: %v", err)
+	}
+	if _, err := f.WriteString(content); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+	f.Close()
+	return f.Name()
+}
+
+// setEnv sets env vars for the duration of the test and restores them on cleanup.
+func setEnv(t *testing.T, pairs ...string) {
+	t.Helper()
+	if len(pairs)%2 != 0 {
+		t.Fatal("setEnv requires an even number of arguments (key, value pairs)")
+	}
+	for i := 0; i < len(pairs); i += 2 {
+		key, val := pairs[i], pairs[i+1]
+		old, existed := os.LookupEnv(key)
+		t.Cleanup(func() {
+			if existed {
+				os.Setenv(key, old)
+			} else {
+				os.Unsetenv(key)
+			}
+		})
+		os.Setenv(key, val)
+	}
+}
+
+// minimalValidConfig returns a YAML string with the minimum required fields.
+func minimalValidConfig(t *testing.T) string {
+	t.Helper()
+	// Create a throwaway private key file so path validation passes at load time.
+	keyFile, err := os.CreateTemp(t.TempDir(), "key-*.pem")
+	if err != nil {
+		t.Fatalf("create key file: %v", err)
+	}
+	keyFile.Close()
+	return `
+server:
+  token: test-token
+tenancies:
+  - name: my-tenancy
+    region: us-ashburn-1
+    tenancy_id: ocid1.tenancy.oc1..aaaa
+    user_id: ocid1.user.oc1..aaaa
+    fingerprint: "aa:bb:cc"
+    private_key_path: ` + keyFile.Name() + `
+`
+}
+
+// ---- defaults ---------------------------------------------------------------
+
+func TestDefaults(t *testing.T) {
+	d := defaults()
+
+	if d.Server.Port != 8080 {
+		t.Errorf("default port: got %d, want 8080", d.Server.Port)
+	}
+	if d.Discovery.TagKey != "monitoring" {
+		t.Errorf("default tag_key: got %q, want %q", d.Discovery.TagKey, "monitoring")
+	}
+	if d.Discovery.TagValue != "enabled" {
+		t.Errorf("default tag_value: got %q, want %q", d.Discovery.TagValue, "enabled")
+	}
+	if d.Discovery.LinuxPort != 9100 {
+		t.Errorf("default linux_port: got %d, want 9100", d.Discovery.LinuxPort)
+	}
+	if d.Discovery.WindowsPort != 9182 {
+		t.Errorf("default windows_port: got %d, want 9182", d.Discovery.WindowsPort)
+	}
+	if d.Discovery.RefreshInterval != 5*time.Minute {
+		t.Errorf("default refresh_interval: got %v, want 5m", d.Discovery.RefreshInterval)
+	}
+	if d.Discovery.RateLimitRPS != 10.0 {
+		t.Errorf("default rate_limit_rps: got %f, want 10.0", d.Discovery.RateLimitRPS)
+	}
+	if d.Server.Token != "" {
+		t.Errorf("default token should be empty, got %q", d.Server.Token)
+	}
+}
+
+// ---- Load: missing file is OK -----------------------------------------------
+
+func TestLoad_NoFileWithEnvVars(t *testing.T) {
+	setEnv(t,
+		"CONFIG_PATH", filepath.Join(t.TempDir(), "nonexistent.yaml"),
+		"SERVER_TOKEN", "mytoken",
+	)
+	// Also provide a minimal tenancy via the env-var path is not possible
+	// (tenancies require the YAML file), so point to a valid file that has
+	// tenancy config but let the token come from the env.
+	cfg := minimalValidConfig(t)
+	path := writeConfigFile(t, cfg)
+	setEnv(t, "CONFIG_PATH", path, "SERVER_TOKEN", "env-token")
+
+	got, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	// Env var takes precedence over file value
+	if got.Server.Token != "env-token" {
+		t.Errorf("token: got %q, want %q", got.Server.Token, "env-token")
+	}
+}
+
+// ---- Load: YAML parsing -----------------------------------------------------
+
+func TestLoad_ParsesYAML(t *testing.T) {
+	tmp := t.TempDir()
+	keyPath := filepath.Join(tmp, "key.pem")
+	if err := os.WriteFile(keyPath, []byte("dummy"), 0600); err != nil {
+		t.Fatalf("write key file: %v", err)
+	}
+
+	yaml := `
+server:
+  port: 9090
+  token: file-token
+discovery:
+  tag_key: env
+  tag_value: true
+  linux_port: 8888
+  windows_port: 7777
+  refresh_interval: 2m
+  rate_limit_rps: 5.0
+tenancies:
+  - name: prod
+    region: eu-frankfurt-1
+    tenancy_id: ocid1.tenancy.oc1..prod
+    user_id: ocid1.user.oc1..prod
+    fingerprint: "11:22:33"
+    private_key_path: ` + keyPath + `
+    compartments:
+      - ocid1.compartment.oc1..aaa
+`
+	path := writeConfigFile(t, yaml)
+	setEnv(t, "CONFIG_PATH", path)
+
+	got, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+
+	if got.Server.Port != 9090 {
+		t.Errorf("port: got %d, want 9090", got.Server.Port)
+	}
+	if got.Server.Token != "file-token" {
+		t.Errorf("token: got %q, want %q", got.Server.Token, "file-token")
+	}
+	if got.Discovery.TagKey != "env" {
+		t.Errorf("tag_key: got %q, want %q", got.Discovery.TagKey, "env")
+	}
+	if got.Discovery.LinuxPort != 8888 {
+		t.Errorf("linux_port: got %d, want 8888", got.Discovery.LinuxPort)
+	}
+	if got.Discovery.WindowsPort != 7777 {
+		t.Errorf("windows_port: got %d, want 7777", got.Discovery.WindowsPort)
+	}
+	if got.Discovery.RefreshInterval != 2*time.Minute {
+		t.Errorf("refresh_interval: got %v, want 2m", got.Discovery.RefreshInterval)
+	}
+	if got.Discovery.RateLimitRPS != 5.0 {
+		t.Errorf("rate_limit_rps: got %f, want 5.0", got.Discovery.RateLimitRPS)
+	}
+	if len(got.Tenancies) != 1 {
+		t.Fatalf("tenancies count: got %d, want 1", len(got.Tenancies))
+	}
+	if got.Tenancies[0].Name != "prod" {
+		t.Errorf("tenancy name: got %q, want %q", got.Tenancies[0].Name, "prod")
+	}
+	if len(got.Tenancies[0].Compartments) != 1 {
+		t.Errorf("compartments count: got %d, want 1", len(got.Tenancies[0].Compartments))
+	}
+}
+
+// ---- Load: env var overrides ------------------------------------------------
+
+func TestLoad_EnvVarOverrides(t *testing.T) {
+	path := writeConfigFile(t, minimalValidConfig(t))
+
+	setEnv(t,
+		"CONFIG_PATH", path,
+		"SERVER_PORT", "9999",
+		"DISCOVERY_TAG_KEY", "my-tag",
+		"DISCOVERY_TAG_VALUE", "yes",
+		"DISCOVERY_LINUX_PORT", "1234",
+		"DISCOVERY_WINDOWS_PORT", "5678",
+		"DISCOVERY_REFRESH_INTERVAL", "10m",
+		"DISCOVERY_RATE_LIMIT_RPS", "20.5",
+	)
+
+	got, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+
+	if got.Server.Port != 9999 {
+		t.Errorf("port: got %d, want 9999", got.Server.Port)
+	}
+	if got.Discovery.TagKey != "my-tag" {
+		t.Errorf("tag_key: got %q, want %q", got.Discovery.TagKey, "my-tag")
+	}
+	if got.Discovery.TagValue != "yes" {
+		t.Errorf("tag_value: got %q, want %q", got.Discovery.TagValue, "yes")
+	}
+	if got.Discovery.LinuxPort != 1234 {
+		t.Errorf("linux_port: got %d, want 1234", got.Discovery.LinuxPort)
+	}
+	if got.Discovery.WindowsPort != 5678 {
+		t.Errorf("windows_port: got %d, want 5678", got.Discovery.WindowsPort)
+	}
+	if got.Discovery.RefreshInterval != 10*time.Minute {
+		t.Errorf("refresh_interval: got %v, want 10m", got.Discovery.RefreshInterval)
+	}
+	if got.Discovery.RateLimitRPS != 20.5 {
+		t.Errorf("rate_limit_rps: got %f, want 20.5", got.Discovery.RateLimitRPS)
+	}
+}
+
+// ---- Load: invalid env var values -------------------------------------------
+
+func TestLoad_InvalidEnvVars(t *testing.T) {
+	path := writeConfigFile(t, minimalValidConfig(t))
+
+	cases := []struct {
+		name   string
+		envKey string
+		val    string
+	}{
+		{"invalid SERVER_PORT", "SERVER_PORT", "not-a-number"},
+		{"invalid DISCOVERY_LINUX_PORT", "DISCOVERY_LINUX_PORT", "abc"},
+		{"invalid DISCOVERY_WINDOWS_PORT", "DISCOVERY_WINDOWS_PORT", "xyz"},
+		{"invalid DISCOVERY_REFRESH_INTERVAL", "DISCOVERY_REFRESH_INTERVAL", "bad-duration"},
+		{"invalid DISCOVERY_RATE_LIMIT_RPS", "DISCOVERY_RATE_LIMIT_RPS", "nope"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			setEnv(t, "CONFIG_PATH", path, tc.envKey, tc.val)
+			_, err := Load()
+			if err == nil {
+				t.Errorf("expected error for %s=%q, got nil", tc.envKey, tc.val)
+			}
+		})
+	}
+}
+
+// ---- Load: invalid YAML -----------------------------------------------------
+
+func TestLoad_InvalidYAML(t *testing.T) {
+	path := writeConfigFile(t, ":::not valid yaml:::")
+	setEnv(t, "CONFIG_PATH", path)
+
+	_, err := Load()
+	if err == nil {
+		t.Error("expected error for invalid YAML, got nil")
+	}
+}
+
+// ---- validate ---------------------------------------------------------------
+
+func TestValidate_MissingToken(t *testing.T) {
+	c := defaults()
+	c.Tenancies = []TenancyConfig{{
+		Name: "t", Region: "r", TenancyID: "tid", UserID: "uid",
+		Fingerprint: "fp", PrivateKeyPath: "/k",
+	}}
+	if err := c.validate(); err == nil {
+		t.Error("expected error for missing token")
+	}
+}
+
+func TestValidate_NoTenancies(t *testing.T) {
+	c := defaults()
+	c.Server.Token = "tok"
+	if err := c.validate(); err == nil {
+		t.Error("expected error for no tenancies")
+	}
+}
+
+func TestValidate_TenancyRequiredFields(t *testing.T) {
+	base := TenancyConfig{
+		Name: "t", Region: "r", TenancyID: "tid", UserID: "uid",
+		Fingerprint: "fp", PrivateKeyPath: "/k",
+	}
+
+	cases := []struct {
+		name   string
+		mutate func(*TenancyConfig)
+	}{
+		{"missing name", func(c *TenancyConfig) { c.Name = "" }},
+		{"missing tenancy_id", func(c *TenancyConfig) { c.TenancyID = "" }},
+		{"missing user_id", func(c *TenancyConfig) { c.UserID = "" }},
+		{"missing region", func(c *TenancyConfig) { c.Region = "" }},
+		{"missing fingerprint", func(c *TenancyConfig) { c.Fingerprint = "" }},
+		{"missing private_key_path", func(c *TenancyConfig) { c.PrivateKeyPath = "" }},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc := tc
+			tenancy := base
+			tc.mutate(&tenancy)
+			cfg := defaults()
+			cfg.Server.Token = "tok"
+			cfg.Tenancies = []TenancyConfig{tenancy}
+			if err := cfg.validate(); err == nil {
+				t.Errorf("expected validation error for %s", tc.name)
+			}
+		})
+	}
+}
+
+func TestValidate_ValidConfig(t *testing.T) {
+	c := defaults()
+	c.Server.Token = "tok"
+	c.Tenancies = []TenancyConfig{{
+		Name: "t", Region: "r", TenancyID: "tid", UserID: "uid",
+		Fingerprint: "fp", PrivateKeyPath: "/k",
+	}}
+	if err := c.validate(); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestValidate_EmptyCompartmentsIsValid(t *testing.T) {
+	c := defaults()
+	c.Server.Token = "tok"
+	c.Tenancies = []TenancyConfig{{
+		Name: "t", Region: "r", TenancyID: "tid", UserID: "uid",
+		Fingerprint: "fp", PrivateKeyPath: "/k",
+		Compartments: []string{}, // explicitly empty - should be valid
+	}}
+	if err := c.validate(); err != nil {
+		t.Errorf("empty compartments should be valid: %v", err)
+	}
+}
+
+// ---- envStr -----------------------------------------------------------------
+
+func TestEnvStr(t *testing.T) {
+	setEnv(t, "TEST_ENVSTR_KEY", "hello")
+	if got := envStr("TEST_ENVSTR_KEY", "fallback"); got != "hello" {
+		t.Errorf("got %q, want %q", got, "hello")
+	}
+	os.Unsetenv("TEST_ENVSTR_KEY")
+	if got := envStr("TEST_ENVSTR_KEY", "fallback"); got != "fallback" {
+		t.Errorf("got %q, want %q", got, "fallback")
+	}
+}

--- a/internal/discovery/cache_test.go
+++ b/internal/discovery/cache_test.go
@@ -1,0 +1,457 @@
+package discovery
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/amaanx86/oci-prometheus-sd-proxy/internal/config"
+)
+
+// ---- targetSet --------------------------------------------------------------
+
+func TestTargetSet_Empty(t *testing.T) {
+	s := targetSet(nil)
+	if len(s) != 0 {
+		t.Errorf("expected empty set, got %d entries", len(s))
+	}
+}
+
+func TestTargetSet_SingleGroup(t *testing.T) {
+	groups := []TargetGroup{
+		{Targets: []string{"10.0.0.1:9100", "10.0.0.2:9100"}},
+	}
+	s := targetSet(groups)
+	if len(s) != 2 {
+		t.Errorf("set size: got %d, want 2", len(s))
+	}
+	if _, ok := s["10.0.0.1:9100"]; !ok {
+		t.Error("10.0.0.1:9100 missing from set")
+	}
+	if _, ok := s["10.0.0.2:9100"]; !ok {
+		t.Error("10.0.0.2:9100 missing from set")
+	}
+}
+
+func TestTargetSet_MultipleGroups(t *testing.T) {
+	groups := []TargetGroup{
+		{Targets: []string{"10.0.0.1:9100"}},
+		{Targets: []string{"10.0.0.2:9100", "10.0.0.3:9100"}},
+	}
+	s := targetSet(groups)
+	if len(s) != 3 {
+		t.Errorf("set size: got %d, want 3", len(s))
+	}
+}
+
+func TestTargetSet_Deduplicates(t *testing.T) {
+	groups := []TargetGroup{
+		{Targets: []string{"10.0.0.1:9100"}},
+		{Targets: []string{"10.0.0.1:9100"}}, // duplicate
+	}
+	s := targetSet(groups)
+	if len(s) != 1 {
+		t.Errorf("set size with duplicates: got %d, want 1", len(s))
+	}
+}
+
+func TestTargetSet_EmptyTargetsSlice(t *testing.T) {
+	groups := []TargetGroup{
+		{Targets: []string{}},
+		{Targets: nil},
+	}
+	s := targetSet(groups)
+	if len(s) != 0 {
+		t.Errorf("expected empty set for groups with no targets, got %d", len(s))
+	}
+}
+
+// ---- computeDelta -----------------------------------------------------------
+
+func TestComputeDelta_AllNew(t *testing.T) {
+	prev := map[string]struct{}{}
+	curr := map[string]struct{}{
+		"10.0.0.1:9100": {},
+		"10.0.0.2:9100": {},
+	}
+	added, removed, unchanged := computeDelta(prev, curr)
+	if added != 2 {
+		t.Errorf("added: got %d, want 2", added)
+	}
+	if removed != 0 {
+		t.Errorf("removed: got %d, want 0", removed)
+	}
+	if unchanged != 0 {
+		t.Errorf("unchanged: got %d, want 0", unchanged)
+	}
+}
+
+func TestComputeDelta_AllRemoved(t *testing.T) {
+	prev := map[string]struct{}{
+		"10.0.0.1:9100": {},
+		"10.0.0.2:9100": {},
+	}
+	curr := map[string]struct{}{}
+	added, removed, unchanged := computeDelta(prev, curr)
+	if added != 0 {
+		t.Errorf("added: got %d, want 0", added)
+	}
+	if removed != 2 {
+		t.Errorf("removed: got %d, want 2", removed)
+	}
+	if unchanged != 0 {
+		t.Errorf("unchanged: got %d, want 0", unchanged)
+	}
+}
+
+func TestComputeDelta_NoChange(t *testing.T) {
+	set := map[string]struct{}{
+		"10.0.0.1:9100": {},
+		"10.0.0.2:9100": {},
+	}
+	added, removed, unchanged := computeDelta(set, set)
+	if added != 0 {
+		t.Errorf("added: got %d, want 0", added)
+	}
+	if removed != 0 {
+		t.Errorf("removed: got %d, want 0", removed)
+	}
+	if unchanged != 2 {
+		t.Errorf("unchanged: got %d, want 2", unchanged)
+	}
+}
+
+func TestComputeDelta_Mixed(t *testing.T) {
+	prev := map[string]struct{}{
+		"10.0.0.1:9100": {},
+		"10.0.0.2:9100": {},
+	}
+	curr := map[string]struct{}{
+		"10.0.0.2:9100": {}, // unchanged
+		"10.0.0.3:9100": {}, // new
+	}
+	added, removed, unchanged := computeDelta(prev, curr)
+	if added != 1 {
+		t.Errorf("added: got %d, want 1", added)
+	}
+	if removed != 1 {
+		t.Errorf("removed: got %d, want 1", removed)
+	}
+	if unchanged != 1 {
+		t.Errorf("unchanged: got %d, want 1", unchanged)
+	}
+}
+
+func TestComputeDelta_BothEmpty(t *testing.T) {
+	added, removed, unchanged := computeDelta(
+		map[string]struct{}{},
+		map[string]struct{}{},
+	)
+	if added != 0 || removed != 0 || unchanged != 0 {
+		t.Errorf("both empty: got added=%d removed=%d unchanged=%d, want all 0",
+			added, removed, unchanged)
+	}
+}
+
+// ---- Cache.Get / Cache.LastError --------------------------------------------
+
+// We test Cache.Get and Cache.LastError without triggering any OCI calls
+// by directly manipulating the internal state under the mutex.
+
+func TestCache_GetReturnsEmptySliceWhenNil(t *testing.T) {
+	c := &Cache{
+		prevTargetSet:    make(map[string]struct{}),
+		failingTenancies: make(map[string]bool),
+	}
+	got := c.Get()
+	if got == nil {
+		t.Error("Get() returned nil, want empty slice")
+	}
+	if len(got) != 0 {
+		t.Errorf("Get() length: got %d, want 0", len(got))
+	}
+}
+
+func TestCache_GetReturnsStoredTargets(t *testing.T) {
+	c := &Cache{
+		prevTargetSet:    make(map[string]struct{}),
+		failingTenancies: make(map[string]bool),
+	}
+
+	want := []TargetGroup{
+		{Targets: []string{"10.0.0.1:9100"}, Labels: map[string]string{"k": "v"}},
+	}
+	c.targets = want
+
+	got := c.Get()
+	if len(got) != len(want) {
+		t.Fatalf("Get() count: got %d, want %d", len(got), len(want))
+	}
+	if got[0].Targets[0] != want[0].Targets[0] {
+		t.Errorf("target address: got %q, want %q", got[0].Targets[0], want[0].Targets[0])
+	}
+}
+
+func TestCache_LastErrorNilByDefault(t *testing.T) {
+	c := &Cache{
+		prevTargetSet:    make(map[string]struct{}),
+		failingTenancies: make(map[string]bool),
+	}
+	if err := c.LastError(); err != nil {
+		t.Errorf("LastError() got %v, want nil", err)
+	}
+}
+
+func TestCache_LastErrorReturnsStoredError(t *testing.T) {
+	c := &Cache{
+		prevTargetSet:    make(map[string]struct{}),
+		failingTenancies: make(map[string]bool),
+	}
+	sentinel := errSentinel("test error")
+	c.lastErr = sentinel
+
+	if got := c.LastError(); got != sentinel {
+		t.Errorf("LastError(): got %v, want %v", got, sentinel)
+	}
+}
+
+// TestCache_GetConcurrentSafe verifies no data races under concurrent reads.
+func TestCache_GetConcurrentSafe(t *testing.T) {
+	c := &Cache{
+		prevTargetSet:    make(map[string]struct{}),
+		failingTenancies: make(map[string]bool),
+		targets: []TargetGroup{
+			{Targets: []string{"10.0.0.1:9100"}},
+		},
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = c.Get()
+		}()
+	}
+	wg.Wait()
+}
+
+// TestCache_GetAndWriteConcurrentSafe verifies no data races with concurrent
+// reads and writes (simulating what the background refresh goroutine does).
+func TestCache_GetAndWriteConcurrentSafe(t *testing.T) {
+	c := &Cache{
+		prevTargetSet:    make(map[string]struct{}),
+		failingTenancies: make(map[string]bool),
+	}
+
+	var wg sync.WaitGroup
+
+	// Writers
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			c.mu.Lock()
+			c.targets = []TargetGroup{{Targets: []string{"10.0.0.1:9100"}}}
+			c.mu.Unlock()
+		}(i)
+	}
+
+	// Readers
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = c.Get()
+		}()
+	}
+
+	wg.Wait()
+}
+
+// ---- NewCache ---------------------------------------------------------------
+
+func TestNewCache_NotNil(t *testing.T) {
+	cfg := minimalCacheConfig()
+	c := NewCache(cfg)
+	if c == nil {
+		t.Fatal("NewCache returned nil")
+	}
+}
+
+func TestNewCache_InitialisedFields(t *testing.T) {
+	cfg := minimalCacheConfig()
+	c := NewCache(cfg)
+
+	if c.cfg != cfg {
+		t.Error("cfg not stored on Cache")
+	}
+	if c.prevTargetSet == nil {
+		t.Error("prevTargetSet should be initialised (not nil)")
+	}
+	if c.failingTenancies == nil {
+		t.Error("failingTenancies should be initialised (not nil)")
+	}
+}
+
+func TestNewCache_GetBeforeStartReturnsEmpty(t *testing.T) {
+	cfg := minimalCacheConfig()
+	c := NewCache(cfg)
+	got := c.Get()
+	if len(got) != 0 {
+		t.Errorf("Get() before Start: got %d items, want 0", len(got))
+	}
+}
+
+// ---- refresh (error path via missing key file) ------------------------------
+//
+// These tests exercise refresh/discoverTenancy when the private_key_path does
+// not exist. The OCI read fails immediately - no network calls are made. This
+// covers the "all tenancies failed - preserve stale data" branch.
+
+func minimalCacheConfig() *config.Config {
+	return &config.Config{
+		Server: config.ServerConfig{Token: "tok"},
+		Discovery: config.DiscoveryConfig{
+			TagKey:          "monitoring",
+			TagValue:        "enabled",
+			LinuxPort:       9100,
+			WindowsPort:     9182,
+			RefreshInterval: time.Hour, // long - we drive refresh manually in tests
+			RateLimitRPS:    10,
+		},
+		Tenancies: []config.TenancyConfig{
+			{
+				Name:           "test-tenancy",
+				Region:         "us-ashburn-1",
+				TenancyID:      "ocid1.tenancy.oc1..test",
+				UserID:         "ocid1.user.oc1..test",
+				Fingerprint:    "aa:bb",
+				PrivateKeyPath: "/nonexistent-key-for-testing.pem", // intentionally missing
+			},
+		},
+	}
+}
+
+func TestCache_RefreshAllTenanciesFail_PreservesEmptyTargets(t *testing.T) {
+	cfg := minimalCacheConfig()
+	c := NewCache(cfg)
+
+	c.refresh(context.Background())
+
+	// When all tenancies fail and there is no prior data, targets stay nil/empty.
+	got := c.Get()
+	if len(got) != 0 {
+		t.Errorf("Get() after all-fail refresh: got %d items, want 0", len(got))
+	}
+}
+
+func TestCache_RefreshAllTenanciesFail_PreservesStaleTargets(t *testing.T) {
+	cfg := minimalCacheConfig()
+	c := NewCache(cfg)
+
+	// Pre-seed the cache with stale data.
+	stale := []TargetGroup{{Targets: []string{"10.0.0.1:9100"}, Labels: map[string]string{}}}
+	c.mu.Lock()
+	c.targets = stale
+	c.mu.Unlock()
+
+	c.refresh(context.Background())
+
+	// Stale data must be preserved when all tenancies fail.
+	got := c.Get()
+	if len(got) != 1 {
+		t.Fatalf("stale data not preserved: got %d groups, want 1", len(got))
+	}
+	if got[0].Targets[0] != "10.0.0.1:9100" {
+		t.Errorf("stale target: got %q, want %q", got[0].Targets[0], "10.0.0.1:9100")
+	}
+}
+
+func TestCache_RefreshIncrementsSeqID(t *testing.T) {
+	cfg := minimalCacheConfig()
+	c := NewCache(cfg)
+
+	before := c.cycleSeq
+	c.refresh(context.Background())
+	if c.cycleSeq != before+1 {
+		t.Errorf("cycleSeq: got %d, want %d", c.cycleSeq, before+1)
+	}
+}
+
+func TestCache_RefreshMultipleCycles_SeqIDIncreases(t *testing.T) {
+	cfg := minimalCacheConfig()
+	c := NewCache(cfg)
+
+	for i := 1; i <= 3; i++ {
+		c.refresh(context.Background())
+		if int(c.cycleSeq) != i {
+			t.Errorf("cycle %d: cycleSeq = %d, want %d", i, c.cycleSeq, i)
+		}
+	}
+}
+
+// TestCache_Start_DoesNotPanic verifies Start completes the initial refresh
+// and launches the background goroutine without panicking, even when all
+// tenancy key files are missing (OCI calls never happen).
+func TestCache_Start_DoesNotPanic(t *testing.T) {
+	cfg := minimalCacheConfig()
+	cfg.Discovery.RefreshInterval = 10 * time.Millisecond
+	c := NewCache(cfg)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Start does initial sync refresh then spawns background goroutine.
+	// With missing key file, discoverTenancy errors immediately - no network.
+	c.Start(ctx)
+
+	// After Start: cache should have gone through one refresh cycle.
+	if c.cycleSeq != 1 {
+		t.Errorf("cycleSeq after Start: got %d, want 1", c.cycleSeq)
+	}
+
+	// Get() must never panic or return nil.
+	got := c.Get()
+	if got == nil {
+		t.Error("Get() returned nil after Start")
+	}
+
+	// Cancel and give the ticker goroutine time to exit cleanly.
+	cancel()
+	time.Sleep(50 * time.Millisecond)
+}
+
+// TestCache_Start_BackgroundTickerRefreshes verifies that the background ticker
+// fires without panicking. We observe this safely via LastError(), which is
+// mutex-protected and gets set after at least one background refresh cycle.
+// (With a missing key file the error path runs, so LastError stays nil because
+// all tenancies failed and stale-preserve logic skips the update - but Get()
+// remains stable and race-free.)
+func TestCache_Start_BackgroundTickerRefreshes(t *testing.T) {
+	cfg := minimalCacheConfig()
+	cfg.Discovery.RefreshInterval = 20 * time.Millisecond
+	c := NewCache(cfg)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	c.Start(ctx)
+
+	// Sleep long enough for at least two ticker intervals to fire.
+	time.Sleep(100 * time.Millisecond)
+
+	// Get() must always be safe to call - ticker goroutine must not have panicked.
+	got := c.Get()
+	if got == nil {
+		t.Error("Get() returned nil after background ticks")
+	}
+	// LastError is mutex-protected and safe to read concurrently.
+	_ = c.LastError()
+}
+
+// errSentinel is a simple error type for testing.
+type errSentinel string
+
+func (e errSentinel) Error() string { return string(e) }

--- a/internal/discovery/oci_test.go
+++ b/internal/discovery/oci_test.go
@@ -1,0 +1,475 @@
+package discovery
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/url"
+	"testing"
+
+	"github.com/oracle/oci-go-sdk/v65/core"
+
+	"github.com/amaanx86/oci-prometheus-sd-proxy/internal/config"
+)
+
+// ---- helpers ----------------------------------------------------------------
+
+func strPtr(s string) *string { return &s }
+
+func makeInstance(opts ...func(*core.Instance)) core.Instance {
+	inst := core.Instance{
+		Id:                 strPtr("ocid1.instance.oc1..test"),
+		DisplayName:        strPtr("test-instance"),
+		Shape:              strPtr("VM.Standard.E4.Flex"),
+		AvailabilityDomain: strPtr("AD-1"),
+		FaultDomain:        strPtr("FAULT-DOMAIN-1"),
+		ImageId:            strPtr("ocid1.image.oc1..img"),
+		LifecycleState:     core.InstanceLifecycleStateRunning,
+		FreeformTags:       map[string]string{},
+		DefinedTags:        map[string]map[string]interface{}{},
+	}
+	for _, o := range opts {
+		o(&inst)
+	}
+	return inst
+}
+
+// ---- hasTag -----------------------------------------------------------------
+
+func TestHasTag_FreeformTagMatch(t *testing.T) {
+	inst := makeInstance(func(i *core.Instance) {
+		i.FreeformTags = map[string]string{"monitoring": "enabled"}
+	})
+	if !hasTag(inst, "monitoring", "enabled") {
+		t.Error("expected hasTag to return true for matching freeform tag")
+	}
+}
+
+func TestHasTag_FreeformTagMismatchValue(t *testing.T) {
+	inst := makeInstance(func(i *core.Instance) {
+		i.FreeformTags = map[string]string{"monitoring": "disabled"}
+	})
+	if hasTag(inst, "monitoring", "enabled") {
+		t.Error("expected hasTag to return false when value doesn't match")
+	}
+}
+
+func TestHasTag_FreeformTagMissingKey(t *testing.T) {
+	inst := makeInstance()
+	if hasTag(inst, "monitoring", "enabled") {
+		t.Error("expected hasTag to return false when key absent")
+	}
+}
+
+func TestHasTag_DefinedTagMatch(t *testing.T) {
+	inst := makeInstance(func(i *core.Instance) {
+		i.DefinedTags = map[string]map[string]interface{}{
+			"ops-namespace": {"monitoring": "enabled"},
+		}
+	})
+	if !hasTag(inst, "monitoring", "enabled") {
+		t.Error("expected hasTag to return true for matching defined tag")
+	}
+}
+
+func TestHasTag_DefinedTagMismatchValue(t *testing.T) {
+	inst := makeInstance(func(i *core.Instance) {
+		i.DefinedTags = map[string]map[string]interface{}{
+			"ops-namespace": {"monitoring": "disabled"},
+		}
+	})
+	if hasTag(inst, "monitoring", "enabled") {
+		t.Error("expected hasTag to return false when defined tag value doesn't match")
+	}
+}
+
+func TestHasTag_DefinedTagNonStringValue(t *testing.T) {
+	inst := makeInstance(func(i *core.Instance) {
+		i.DefinedTags = map[string]map[string]interface{}{
+			"ops-namespace": {"monitoring": 42}, // non-string value
+		}
+	})
+	if hasTag(inst, "monitoring", "42") {
+		t.Error("expected hasTag to return false for non-string defined tag value")
+	}
+}
+
+func TestHasTag_FreeformTakesPrecedenceOverDefined(t *testing.T) {
+	// Freeform matches - defined doesn't - should still return true
+	inst := makeInstance(func(i *core.Instance) {
+		i.FreeformTags = map[string]string{"monitoring": "enabled"}
+		i.DefinedTags = map[string]map[string]interface{}{
+			"ns": {"monitoring": "disabled"},
+		}
+	})
+	if !hasTag(inst, "monitoring", "enabled") {
+		t.Error("expected hasTag to return true when freeform matches even if defined doesn't")
+	}
+}
+
+func TestHasTag_MultipleNamespaces(t *testing.T) {
+	inst := makeInstance(func(i *core.Instance) {
+		i.DefinedTags = map[string]map[string]interface{}{
+			"ns1": {"other": "x"},
+			"ns2": {"monitoring": "enabled"},
+		}
+	})
+	if !hasTag(inst, "monitoring", "enabled") {
+		t.Error("expected hasTag to find tag in second namespace")
+	}
+}
+
+func TestHasTag_NilFreeformTags(t *testing.T) {
+	inst := makeInstance(func(i *core.Instance) {
+		i.FreeformTags = nil
+		i.DefinedTags = nil
+	})
+	// Should not panic
+	if hasTag(inst, "monitoring", "enabled") {
+		t.Error("expected false with nil tags")
+	}
+}
+
+// ---- isWindows --------------------------------------------------------------
+
+func TestIsWindows_FreeformTagWindows(t *testing.T) {
+	cases := []struct {
+		name  string
+		osVal string
+		want  bool
+	}{
+		{"lowercase windows", "windows", true},
+		{"uppercase WINDOWS", "WINDOWS", true},
+		{"mixed case Windows", "Windows", true},
+		{"linux", "linux", false},
+		{"empty", "", false},
+		{"windows-2019", "windows-2019", false}, // only exact match via EqualFold
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			inst := makeInstance(func(i *core.Instance) {
+				if tc.osVal != "" {
+					i.FreeformTags = map[string]string{"os": tc.osVal}
+				}
+			})
+			if got := isWindows(inst); got != tc.want {
+				t.Errorf("isWindows(%q): got %v, want %v", tc.osVal, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsWindows_NoOsTag(t *testing.T) {
+	inst := makeInstance()
+	if isWindows(inst) {
+		t.Error("expected isWindows to return false when os tag is absent")
+	}
+}
+
+// ---- buildLabels ------------------------------------------------------------
+
+func TestBuildLabels_CoreLabelsPresent(t *testing.T) {
+	tenancy := config.TenancyConfig{
+		Name:      "prod",
+		TenancyID: "ocid1.tenancy.oc1..prod",
+		Region:    "us-ashburn-1",
+	}
+	inst := makeInstance(func(i *core.Instance) {
+		i.LifecycleState = core.InstanceLifecycleStateRunning
+	})
+	labels := buildLabels(tenancy, "ocid1.compartment.oc1..comp", inst, "10.0.0.5")
+
+	required := map[string]string{
+		"__meta_oci_tenancy_name":   "prod",
+		"__meta_oci_tenancy_id":     "ocid1.tenancy.oc1..prod",
+		"__meta_oci_region":         "us-ashburn-1",
+		"__meta_oci_compartment_id": "ocid1.compartment.oc1..comp",
+		"__meta_oci_private_ip":     "10.0.0.5",
+		"__meta_oci_instance_state": "RUNNING",
+		"__meta_oci_instance_id":    "ocid1.instance.oc1..test",
+		"__meta_oci_instance_name":  "test-instance",
+		"__meta_oci_display_name":   "test-instance",
+		"__meta_oci_shape":          "VM.Standard.E4.Flex",
+		"__meta_oci_availability_domain": "AD-1",
+		"__meta_oci_fault_domain":   "FAULT-DOMAIN-1",
+		"__meta_oci_image_id":       "ocid1.image.oc1..img",
+	}
+
+	for key, want := range required {
+		if got := labels[key]; got != want {
+			t.Errorf("label %q: got %q, want %q", key, got, want)
+		}
+	}
+}
+
+func TestBuildLabels_FreeformTagsExposed(t *testing.T) {
+	tenancy := config.TenancyConfig{Name: "t", TenancyID: "tid", Region: "r"}
+	inst := makeInstance(func(i *core.Instance) {
+		i.FreeformTags = map[string]string{
+			"environment": "production",
+			"team":        "platform",
+		}
+	})
+	labels := buildLabels(tenancy, "comp", inst, "10.0.0.1")
+
+	if labels["__meta_oci_tag_environment"] != "production" {
+		t.Errorf("freeform tag 'environment': got %q, want %q",
+			labels["__meta_oci_tag_environment"], "production")
+	}
+	if labels["__meta_oci_tag_team"] != "platform" {
+		t.Errorf("freeform tag 'team': got %q, want %q",
+			labels["__meta_oci_tag_team"], "platform")
+	}
+}
+
+func TestBuildLabels_FreeformTagKeySanitized(t *testing.T) {
+	tenancy := config.TenancyConfig{Name: "t", TenancyID: "tid", Region: "r"}
+	inst := makeInstance(func(i *core.Instance) {
+		i.FreeformTags = map[string]string{
+			"My-Tag.Key": "value",
+		}
+	})
+	labels := buildLabels(tenancy, "comp", inst, "10.0.0.1")
+
+	// Key should be lowercased and special chars replaced with _
+	if _, ok := labels["__meta_oci_tag_my_tag_key"]; !ok {
+		t.Error("expected sanitized tag key '__meta_oci_tag_my_tag_key' not found")
+	}
+}
+
+func TestBuildLabels_NilOptionalFields(t *testing.T) {
+	tenancy := config.TenancyConfig{Name: "t", TenancyID: "tid", Region: "r"}
+	inst := core.Instance{
+		Id:             nil,
+		DisplayName:    nil,
+		Shape:          nil,
+		AvailabilityDomain: nil,
+		FaultDomain:    nil,
+		ImageId:        nil,
+		LifecycleState: core.InstanceLifecycleStateRunning,
+		FreeformTags:   map[string]string{},
+		DefinedTags:    map[string]map[string]interface{}{},
+	}
+	// Should not panic on nil pointer fields
+	labels := buildLabels(tenancy, "comp", inst, "10.0.0.1")
+
+	// Mandatory labels must still be present
+	if labels["__meta_oci_private_ip"] != "10.0.0.1" {
+		t.Error("private IP label missing with nil optional fields")
+	}
+	// Optional labels should be absent (not panic)
+	if _, ok := labels["__meta_oci_instance_id"]; ok {
+		t.Error("instance_id should be absent when Id is nil")
+	}
+}
+
+// ---- sanitizeLabelKey -------------------------------------------------------
+
+func TestSanitizeLabelKey(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{"monitoring", "monitoring"},
+		{"Monitoring", "monitoring"},
+		{"my-tag", "my_tag"},
+		{"my.tag.key", "my_tag_key"},
+		{"My-Tag.Key", "my_tag_key"},
+		{"tag with spaces", "tag_with_spaces"},
+		{"tag123", "tag123"},
+		{"123tag", "123tag"},
+		{"", ""},
+		{"__reserved__", "__reserved__"},
+		{"CamelCase", "camelcase"},
+		{"mixed-UPPER_lower.dot", "mixed_upper_lower_dot"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.input, func(t *testing.T) {
+			got := sanitizeLabelKey(tc.input)
+			if got != tc.want {
+				t.Errorf("sanitizeLabelKey(%q): got %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+// ---- extractErrorCode -------------------------------------------------------
+
+func TestExtractErrorCode_ContextCanceled(t *testing.T) {
+	code := extractErrorCode(context.Canceled)
+	if code != "context_canceled" {
+		t.Errorf("got %q, want %q", code, "context_canceled")
+	}
+}
+
+func TestExtractErrorCode_DeadlineExceeded(t *testing.T) {
+	code := extractErrorCode(context.DeadlineExceeded)
+	if code != "timeout" {
+		t.Errorf("got %q, want %q", code, "timeout")
+	}
+}
+
+func TestExtractErrorCode_URLError(t *testing.T) {
+	urlErr := &url.Error{Op: "Get", URL: "http://example.com", Err: errors.New("connection refused")}
+	code := extractErrorCode(urlErr)
+	if code != "network_error" {
+		t.Errorf("got %q, want %q", code, "network_error")
+	}
+}
+
+func TestExtractErrorCode_NetOpError(t *testing.T) {
+	netErr := &net.OpError{Op: "dial", Net: "tcp", Err: errors.New("refused")}
+	code := extractErrorCode(netErr)
+	if code != "network_error" {
+		t.Errorf("got %q, want %q", code, "network_error")
+	}
+}
+
+func TestExtractErrorCode_UnknownError(t *testing.T) {
+	code := extractErrorCode(errors.New("some unknown error"))
+	if code != "unknown" {
+		t.Errorf("got %q, want %q", code, "unknown")
+	}
+}
+
+func TestExtractErrorCode_WrappedContextCanceled(t *testing.T) {
+	wrapped := fmt.Errorf("outer: %w", context.Canceled)
+	code := extractErrorCode(wrapped)
+	if code != "context_canceled" {
+		t.Errorf("got %q, want %q", code, "context_canceled")
+	}
+}
+
+func TestExtractErrorCode_WrappedDeadlineExceeded(t *testing.T) {
+	wrapped := fmt.Errorf("outer: %w", context.DeadlineExceeded)
+	code := extractErrorCode(wrapped)
+	if code != "timeout" {
+		t.Errorf("got %q, want %q", code, "timeout")
+	}
+}
+
+func TestExtractErrorCode_PlainError_IsUnknown(t *testing.T) {
+	err := errors.New("some arbitrary error")
+	code := extractErrorCode(err)
+	if code != "unknown" {
+		t.Errorf("plain error should be 'unknown', got %q", code)
+	}
+}
+
+func TestExtractErrorCode_WrappedURLError(t *testing.T) {
+	inner := &url.Error{Op: "Get", URL: "http://example.com", Err: errors.New("connection refused")}
+	wrapped := fmt.Errorf("outer: %w", inner)
+	code := extractErrorCode(wrapped)
+	if code != "network_error" {
+		t.Errorf("got %q, want %q", code, "network_error")
+	}
+}
+
+// ---- discoverTenancy (error path: missing key file) -------------------------
+
+func TestDiscoverTenancy_MissingKeyFile(t *testing.T) {
+	cfg := &config.Config{
+		Discovery: config.DiscoveryConfig{
+			TagKey:       "monitoring",
+			TagValue:     "enabled",
+			LinuxPort:    9100,
+			WindowsPort:  9182,
+			RateLimitRPS: 10,
+		},
+	}
+	tenancy := config.TenancyConfig{
+		Name:           "test",
+		Region:         "us-ashburn-1",
+		TenancyID:      "ocid1.tenancy.oc1..test",
+		UserID:         "ocid1.user.oc1..test",
+		Fingerprint:    "aa:bb",
+		PrivateKeyPath: "/nonexistent/path/to/key.pem",
+	}
+
+	_, _, err := discoverTenancy(context.Background(), cfg, tenancy)
+	if err == nil {
+		t.Error("expected error for missing private key file, got nil")
+	}
+}
+
+// ---- hasTag edge cases ------------------------------------------------------
+
+func TestHasTag_EmptyKeyAndValue(t *testing.T) {
+	inst := makeInstance(func(i *core.Instance) {
+		i.FreeformTags = map[string]string{"": ""}
+	})
+	// Empty key with empty value - should match
+	if !hasTag(inst, "", "") {
+		t.Error("expected hasTag to match empty key and empty value")
+	}
+}
+
+func TestHasTag_DefinedTagEmptyNamespace(t *testing.T) {
+	inst := makeInstance(func(i *core.Instance) {
+		i.DefinedTags = map[string]map[string]interface{}{
+			"ns": {},
+		}
+	})
+	if hasTag(inst, "monitoring", "enabled") {
+		t.Error("expected hasTag to return false for empty namespace map")
+	}
+}
+
+// ---- buildLabels: multiple freeform tags ------------------------------------
+
+func TestBuildLabels_MultipleFreeformTagsSanitized(t *testing.T) {
+	tenancy := config.TenancyConfig{Name: "t", TenancyID: "tid", Region: "r"}
+	inst := makeInstance(func(i *core.Instance) {
+		i.FreeformTags = map[string]string{
+			"My.Tag":       "v1",
+			"Another-Tag":  "v2",
+			"simple":       "v3",
+			"123numeric":   "v4",
+		}
+	})
+	labels := buildLabels(tenancy, "comp", inst, "10.0.0.1")
+
+	expected := map[string]string{
+		"__meta_oci_tag_my_tag":     "v1",
+		"__meta_oci_tag_another_tag": "v2",
+		"__meta_oci_tag_simple":     "v3",
+		"__meta_oci_tag_123numeric": "v4",
+	}
+	for key, want := range expected {
+		if got := labels[key]; got != want {
+			t.Errorf("label %q: got %q, want %q", key, got, want)
+		}
+	}
+}
+
+func TestBuildLabels_EmptyFreeformTags(t *testing.T) {
+	tenancy := config.TenancyConfig{Name: "t", TenancyID: "tid", Region: "r"}
+	inst := makeInstance(func(i *core.Instance) {
+		i.FreeformTags = map[string]string{}
+	})
+	labels := buildLabels(tenancy, "comp", inst, "10.0.0.1")
+
+	// No __meta_oci_tag_* keys should be present
+	for k := range labels {
+		if len(k) > len("__meta_oci_tag_") && k[:len("__meta_oci_tag_")] == "__meta_oci_tag_" {
+			// Only allow tags that came from non-empty freeform tags
+			t.Errorf("unexpected tag label %q for empty freeform tags", k)
+			break
+		}
+	}
+}
+
+// ---- isWindows: no freeform tags map ----------------------------------------
+
+func TestIsWindows_NilFreeformTags(t *testing.T) {
+	inst := makeInstance(func(i *core.Instance) {
+		i.FreeformTags = nil
+	})
+	// Should not panic
+	if isWindows(inst) {
+		t.Error("expected false for nil freeform tags")
+	}
+}

--- a/internal/handler/targets_test.go
+++ b/internal/handler/targets_test.go
@@ -1,0 +1,182 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/amaanx86/oci-prometheus-sd-proxy/internal/discovery"
+)
+
+// mockCache implements TargetCache for testing.
+type mockCache struct {
+	targets []discovery.TargetGroup
+}
+
+func (m *mockCache) Get() []discovery.TargetGroup {
+	return m.targets
+}
+
+func TestTargets_GET_ReturnsOK(t *testing.T) {
+	cache := &mockCache{
+		targets: []discovery.TargetGroup{
+			{
+				Targets: []string{"10.0.0.1:9100"},
+				Labels:  map[string]string{"__meta_oci_region": "us-ashburn-1"},
+			},
+		},
+	}
+
+	handler := Targets(cache)
+	req := httptest.NewRequest(http.MethodGet, "/v1/targets", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("status: got %d, want 200", rr.Code)
+	}
+}
+
+func TestTargets_ContentTypeJSON(t *testing.T) {
+	handler := Targets(&mockCache{targets: []discovery.TargetGroup{}})
+	req := httptest.NewRequest(http.MethodGet, "/v1/targets", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	ct := rr.Header().Get("Content-Type")
+	if ct != "application/json; charset=utf-8" {
+		t.Errorf("Content-Type: got %q, want %q", ct, "application/json; charset=utf-8")
+	}
+}
+
+func TestTargets_EmptyCacheReturnsEmptyArray(t *testing.T) {
+	handler := Targets(&mockCache{targets: []discovery.TargetGroup{}})
+	req := httptest.NewRequest(http.MethodGet, "/v1/targets", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("status: got %d, want 200", rr.Code)
+	}
+
+	var result []discovery.TargetGroup
+	if err := json.NewDecoder(rr.Body).Decode(&result); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(result) != 0 {
+		t.Errorf("expected empty array, got %d items", len(result))
+	}
+}
+
+func TestTargets_NonGETMethodNotAllowed(t *testing.T) {
+	handler := Targets(&mockCache{})
+
+	methods := []string{
+		http.MethodPost,
+		http.MethodPut,
+		http.MethodPatch,
+		http.MethodDelete,
+		http.MethodHead,
+		http.MethodOptions,
+	}
+
+	for _, method := range methods {
+		t.Run(method, func(t *testing.T) {
+			req := httptest.NewRequest(method, "/v1/targets", nil)
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+
+			if rr.Code != http.StatusMethodNotAllowed {
+				t.Errorf("%s: got %d, want 405", method, rr.Code)
+			}
+		})
+	}
+}
+
+func TestTargets_ResponseBodyIsValidJSON(t *testing.T) {
+	cache := &mockCache{
+		targets: []discovery.TargetGroup{
+			{
+				Targets: []string{"10.0.0.1:9100", "10.0.0.2:9100"},
+				Labels: map[string]string{
+					"__meta_oci_region":        "us-ashburn-1",
+					"__meta_oci_tenancy_name":  "prod",
+					"__meta_oci_instance_name": "my-instance",
+				},
+			},
+			{
+				Targets: []string{"10.0.0.3:9182"},
+				Labels:  map[string]string{"__meta_oci_region": "eu-frankfurt-1"},
+			},
+		},
+	}
+
+	handler := Targets(cache)
+	req := httptest.NewRequest(http.MethodGet, "/v1/targets", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	var result []discovery.TargetGroup
+	if err := json.NewDecoder(rr.Body).Decode(&result); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	if len(result) != 2 {
+		t.Fatalf("result count: got %d, want 2", len(result))
+	}
+
+	if len(result[0].Targets) != 2 {
+		t.Errorf("first group targets: got %d, want 2", len(result[0].Targets))
+	}
+	if result[0].Labels["__meta_oci_region"] != "us-ashburn-1" {
+		t.Errorf("label: got %q, want %q", result[0].Labels["__meta_oci_region"], "us-ashburn-1")
+	}
+}
+
+func TestTargets_Always200EvenWithData(t *testing.T) {
+	// Prometheus HTTP SD contract: always return 200, never 204 or 5xx
+	cache := &mockCache{
+		targets: []discovery.TargetGroup{
+			{Targets: []string{"1.2.3.4:9100"}, Labels: map[string]string{}},
+		},
+	}
+	handler := Targets(cache)
+	req := httptest.NewRequest(http.MethodGet, "/v1/targets", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("status: got %d, want 200", rr.Code)
+	}
+}
+
+func TestTargets_JSONContainsTargetsAndLabelsKeys(t *testing.T) {
+	cache := &mockCache{
+		targets: []discovery.TargetGroup{
+			{
+				Targets: []string{"10.0.0.1:9100"},
+				Labels:  map[string]string{"job": "node"},
+			},
+		},
+	}
+	handler := Targets(cache)
+	req := httptest.NewRequest(http.MethodGet, "/v1/targets", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	// Decode as a generic slice to check key presence
+	var raw []map[string]json.RawMessage
+	if err := json.NewDecoder(rr.Body).Decode(&raw); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(raw) == 0 {
+		t.Fatal("expected at least one group")
+	}
+	if _, ok := raw[0]["targets"]; !ok {
+		t.Error("response missing 'targets' key")
+	}
+	if _, ok := raw[0]["labels"]; !ok {
+		t.Error("response missing 'labels' key")
+	}
+}

--- a/internal/middleware/auth_test.go
+++ b/internal/middleware/auth_test.go
@@ -1,0 +1,139 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestBearerAuth(t *testing.T) {
+	const validToken = "super-secret-token"
+
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+
+	handler := BearerAuth(validToken, next)
+
+	cases := []struct {
+		name       string
+		authHeader string
+		wantStatus int
+	}{
+		{
+			name:       "valid bearer token",
+			authHeader: "Bearer " + validToken,
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "missing authorization header",
+			authHeader: "",
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name:       "wrong token",
+			authHeader: "Bearer wrong-token",
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name:       "no Bearer prefix",
+			authHeader: validToken,
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name:       "Basic auth scheme",
+			authHeader: "Basic dXNlcjpwYXNz",
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name:       "empty token value",
+			authHeader: "Bearer ",
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name:       "Bearer prefix only - no space after",
+			authHeader: "Bearer",
+			wantStatus: http.StatusUnauthorized,
+		},
+		{
+			name:       "token with extra whitespace",
+			authHeader: "Bearer " + validToken + " ",
+			wantStatus: http.StatusUnauthorized,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			if tc.authHeader != "" {
+				req.Header.Set("Authorization", tc.authHeader)
+			}
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+
+			if rr.Code != tc.wantStatus {
+				t.Errorf("status: got %d, want %d", rr.Code, tc.wantStatus)
+			}
+		})
+	}
+}
+
+// TestBearerAuth_TimingSafety verifies the handler responds with 401 for all
+// invalid tokens - we can't test constant-time directly, but we confirm the
+// behavior is consistent regardless of how similar the bad token is.
+func TestBearerAuth_TimingSafety(t *testing.T) {
+	const validToken = "aaaaaaaaaaaaaaaa"
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	handler := BearerAuth(validToken, next)
+
+	badTokens := []string{
+		"aaaaaaaaaaaaaaab", // differs only in last char
+		"baaaaaaaaaaaaaaa", // differs only in first char
+		"",
+		"a",
+		"aaaaaaaaaaaaaaaaa", // one char longer
+		"aaaaaaaaaaaaaaa",   // one char shorter
+	}
+
+	for _, bad := range badTokens {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.Header.Set("Authorization", "Bearer "+bad)
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+		if rr.Code != http.StatusUnauthorized {
+			t.Errorf("token %q: got %d, want 401", bad, rr.Code)
+		}
+	}
+}
+
+// TestBearerAuth_NextCalledOnlyOnSuccess ensures the downstream handler is
+// called exactly once on a valid request and never on an invalid one.
+func TestBearerAuth_NextCalledOnlyOnSuccess(t *testing.T) {
+	const token = "tok"
+
+	calls := 0
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.WriteHeader(http.StatusOK)
+	})
+	handler := BearerAuth(token, next)
+
+	// Valid request
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+	if calls != 1 {
+		t.Errorf("next called %d times on valid request, want 1", calls)
+	}
+
+	// Invalid request
+	req2 := httptest.NewRequest(http.MethodGet, "/", nil)
+	req2.Header.Set("Authorization", "Bearer bad")
+	handler.ServeHTTP(httptest.NewRecorder(), req2)
+	if calls != 1 {
+		t.Errorf("next called %d times total after invalid request, want still 1", calls)
+	}
+}

--- a/internal/middleware/logging_test.go
+++ b/internal/middleware/logging_test.go
@@ -1,0 +1,123 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestLogging_PassesRequestToNext(t *testing.T) {
+	called := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := Logging(next)
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if !called {
+		t.Error("Logging middleware did not call next handler")
+	}
+}
+
+func TestLogging_CapturesStatusCode(t *testing.T) {
+	cases := []struct {
+		name       string
+		statusCode int
+	}{
+		{"200 OK", http.StatusOK},
+		{"201 Created", http.StatusCreated},
+		{"400 Bad Request", http.StatusBadRequest},
+		{"401 Unauthorized", http.StatusUnauthorized},
+		{"404 Not Found", http.StatusNotFound},
+		{"500 Internal Server Error", http.StatusInternalServerError},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tc.statusCode)
+			})
+
+			handler := Logging(next)
+			req := httptest.NewRequest(http.MethodGet, "/test", nil)
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+
+			if rr.Code != tc.statusCode {
+				t.Errorf("status code: got %d, want %d", rr.Code, tc.statusCode)
+			}
+		})
+	}
+}
+
+func TestLogging_DefaultStatusIs200(t *testing.T) {
+	// When next handler never calls WriteHeader, the default is 200.
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("body only"))
+	})
+
+	handler := Logging(next)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("status code: got %d, want 200", rr.Code)
+	}
+}
+
+func TestLogging_ResponseBodyPassedThrough(t *testing.T) {
+	want := "hello world"
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(want))
+	})
+
+	handler := Logging(next)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if got := rr.Body.String(); got != want {
+		t.Errorf("body: got %q, want %q", got, want)
+	}
+}
+
+func TestLogging_WithRefreshIntervalHeader(t *testing.T) {
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := Logging(next)
+	req := httptest.NewRequest(http.MethodGet, "/v1/targets", nil)
+	req.Header.Set("X-Prometheus-Refresh-Interval-Seconds", "30")
+	rr := httptest.NewRecorder()
+
+	// Should not panic or error when the header is present
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("status code: got %d, want 200", rr.Code)
+	}
+}
+
+// TestResponseWriter_WriteHeader verifies the custom responseWriter wrapper
+// only records the status once (the first call wins for http.ResponseWriter).
+func TestResponseWriter_WriteHeader(t *testing.T) {
+	rr := httptest.NewRecorder()
+	rw := &responseWriter{ResponseWriter: rr, status: http.StatusOK}
+
+	rw.WriteHeader(http.StatusTeapot)
+	if rw.status != http.StatusTeapot {
+		t.Errorf("status: got %d, want %d", rw.status, http.StatusTeapot)
+	}
+
+	// Underlying recorder should also reflect the status
+	if rr.Code != http.StatusTeapot {
+		t.Errorf("recorder code: got %d, want %d", rr.Code, http.StatusTeapot)
+	}
+}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1,0 +1,256 @@
+package server
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/amaanx86/oci-prometheus-sd-proxy/internal/config"
+	"github.com/amaanx86/oci-prometheus-sd-proxy/internal/discovery"
+)
+
+// testConfig returns a minimal valid config for tests.
+func testConfig() *config.Config {
+	return &config.Config{
+		Server: config.ServerConfig{
+			Port:  8080,
+			Token: "test-token",
+		},
+		Discovery: config.DiscoveryConfig{
+			TagKey:      "monitoring",
+			TagValue:    "enabled",
+			LinuxPort:   9100,
+			WindowsPort: 9182,
+		},
+		Tenancies: []config.TenancyConfig{
+			{
+				Name:           "test",
+				Region:         "us-ashburn-1",
+				TenancyID:      "ocid1.tenancy.oc1..test",
+				UserID:         "ocid1.user.oc1..test",
+				Fingerprint:    "aa:bb:cc",
+				PrivateKeyPath: "/tmp/key.pem",
+			},
+		},
+	}
+}
+
+// ---- helper: spin up a test server from New() -------------------------------
+
+func newTestServer(t *testing.T) (*httptest.Server, *config.Config, *discovery.Cache) {
+	t.Helper()
+	cfg := testConfig()
+	cache := discovery.NewCache(cfg)
+	srv := New(cfg, cache)
+	ts := httptest.NewServer(srv.Handler)
+	t.Cleanup(ts.Close)
+	return ts, cfg, cache
+}
+
+// ---- /healthz ---------------------------------------------------------------
+
+func TestHealthz_Returns200(t *testing.T) {
+	ts, _, _ := newTestServer(t)
+	resp, err := http.Get(ts.URL + "/healthz")
+	if err != nil {
+		t.Fatalf("GET /healthz: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status: got %d, want 200", resp.StatusCode)
+	}
+}
+
+func TestHealthz_ReturnsOKBody(t *testing.T) {
+	ts, _, _ := newTestServer(t)
+	resp, err := http.Get(ts.URL + "/healthz")
+	if err != nil {
+		t.Fatalf("GET /healthz: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) != "ok\n" {
+		t.Errorf("body: got %q, want %q", string(body), "ok\n")
+	}
+}
+
+func TestHealthz_ContentTypePlainText(t *testing.T) {
+	ts, _, _ := newTestServer(t)
+	resp, err := http.Get(ts.URL + "/healthz")
+	if err != nil {
+		t.Fatalf("GET /healthz: %v", err)
+	}
+	defer resp.Body.Close()
+
+	ct := resp.Header.Get("Content-Type")
+	if ct != "text/plain" {
+		t.Errorf("Content-Type: got %q, want %q", ct, "text/plain")
+	}
+}
+
+func TestHealthz_NoAuthRequired(t *testing.T) {
+	ts, _, _ := newTestServer(t)
+	// No Authorization header - should still get 200
+	resp, err := http.Get(ts.URL + "/healthz")
+	if err != nil {
+		t.Fatalf("GET /healthz: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status: got %d, want 200 (no auth required for healthz)", resp.StatusCode)
+	}
+}
+
+// ---- /readyz ----------------------------------------------------------------
+
+func TestReadyz_Returns200(t *testing.T) {
+	ts, _, _ := newTestServer(t)
+	resp, err := http.Get(ts.URL + "/readyz")
+	if err != nil {
+		t.Fatalf("GET /readyz: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status: got %d, want 200", resp.StatusCode)
+	}
+}
+
+func TestReadyz_ReturnsOKBody(t *testing.T) {
+	ts, _, _ := newTestServer(t)
+	resp, err := http.Get(ts.URL + "/readyz")
+	if err != nil {
+		t.Fatalf("GET /readyz: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) != "ok\n" {
+		t.Errorf("body: got %q, want %q", string(body), "ok\n")
+	}
+}
+
+func TestReadyz_NoAuthRequired(t *testing.T) {
+	ts, _, _ := newTestServer(t)
+	resp, err := http.Get(ts.URL + "/readyz")
+	if err != nil {
+		t.Fatalf("GET /readyz: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status: got %d, want 200 (no auth required for readyz)", resp.StatusCode)
+	}
+}
+
+// ---- /v1/targets authentication ---------------------------------------------
+
+func TestTargetsRoute_Unauthenticated(t *testing.T) {
+	ts, _, _ := newTestServer(t)
+	resp, err := http.Get(ts.URL + "/v1/targets")
+	if err != nil {
+		t.Fatalf("GET /v1/targets: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("status: got %d, want 401", resp.StatusCode)
+	}
+}
+
+func TestTargetsRoute_WrongToken(t *testing.T) {
+	ts, _, _ := newTestServer(t)
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/v1/targets", nil)
+	req.Header.Set("Authorization", "Bearer wrong-token")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET /v1/targets: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("status: got %d, want 401", resp.StatusCode)
+	}
+}
+
+func TestTargetsRoute_ValidToken_Returns200(t *testing.T) {
+	ts, cfg, _ := newTestServer(t)
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/v1/targets", nil)
+	req.Header.Set("Authorization", "Bearer "+cfg.Server.Token)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET /v1/targets: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status: got %d, want 200", resp.StatusCode)
+	}
+}
+
+func TestTargetsRoute_ValidToken_ContentTypeJSON(t *testing.T) {
+	ts, cfg, _ := newTestServer(t)
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/v1/targets", nil)
+	req.Header.Set("Authorization", "Bearer "+cfg.Server.Token)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET /v1/targets: %v", err)
+	}
+	defer resp.Body.Close()
+
+	ct := resp.Header.Get("Content-Type")
+	if ct != "application/json; charset=utf-8" {
+		t.Errorf("Content-Type: got %q, want %q", ct, "application/json; charset=utf-8")
+	}
+}
+
+func TestTargetsRoute_POST_MethodNotAllowed(t *testing.T) {
+	ts, cfg, _ := newTestServer(t)
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/targets", nil)
+	req.Header.Set("Authorization", "Bearer "+cfg.Server.Token)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST /v1/targets: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Errorf("status: got %d, want 405", resp.StatusCode)
+	}
+}
+
+// ---- server address ---------------------------------------------------------
+
+func TestNew_ServerAddr(t *testing.T) {
+	cfg := testConfig()
+	cfg.Server.Port = 9999
+	cache := discovery.NewCache(cfg)
+	srv := New(cfg, cache)
+
+	if srv.Addr != ":9999" {
+		t.Errorf("Addr: got %q, want %q", srv.Addr, ":9999")
+	}
+}
+
+// ---- unknown routes ---------------------------------------------------------
+
+func TestUnknownRoute_Returns404(t *testing.T) {
+	ts, _, _ := newTestServer(t)
+	resp, err := http.Get(ts.URL + "/does-not-exist")
+	if err != nil {
+		t.Fatalf("GET /does-not-exist: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("status: got %d, want 404", resp.StatusCode)
+	}
+}


### PR DESCRIPTION
## Description

Adds the initial automated test suite covering all packages, and documents the testing policy to satisfy OpenSSF Best Practices requirements (test, test_policy, tests_are_added, tests_documented_added).

## Type of Change

- [ ] Bug fix (non-breaking)
- [ ] Feature (non-breaking)
- [ ] Breaking change
- [x] Documentation update

## Testing

**New or changed functionality requires automated tests** (see [CONTRIBUTING.md](../CONTRIBUTING.md#testing)).

- [x] `make test` passes (`go test -race -cover ./...`)
- [x] New/changed code has corresponding test cases in `*_test.go`
- [ ] If OCI-calling code was changed, manual integration testing completed

**Test details:**
- Go version: go1.26.1
- Test environment: local

Coverage after this PR:

| Package | Coverage |
|---------|----------|
| config | 96.9% |
| middleware | 100% |
| handler | 100% |
| server | 100% |
| discovery | 43.8% (OCI SDK boundary) |
| total | 59.2% |

## Checklist

- [x] `make lint` passes
- [x] Self-review completed
- [ ] Comments added for complex logic
- [x] Documentation updated (CONTRIBUTING.md, README if needed)
- [x] Tests added or updated for all new functionality
- [ ] All CI checks pass