### PR TITLE
docs: add GitHub private vulnerability reporting link to SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,9 +4,10 @@
 
 Do not open a GitHub issue to report security vulnerabilities.
 
-If you believe you have found a security vulnerability, please report it directly to:
+If you believe you have found a security vulnerability, you can report it privately via either of these channels:
 
-**Email**: [amaanulhaq.s@outlook.com](mailto:amaanulhaq.s@outlook.com)
+- **GitHub**: use [Report a vulnerability](https://github.com/amaanx86/oci-prometheus-sd-proxy/security/advisories/new) (preferred)
+- **Email**: [amaanulhaq.s@outlook.com](mailto:amaanulhaq.s@outlook.com)
 
 Include the following in your report:
 


### PR DESCRIPTION
## Description

Private vulnerability reporting has been enabled on the repo. This updates SECURITY.md to document the GitHub advisory link alongside the existing email address.

Satisfies OpenSSF `vulnerability_report_private` (MUST).

## Type of Change

- [ ] Bug fix (non-breaking)
- [ ] Feature (non-breaking)
- [ ] Breaking change
- [x] Documentation update

## Testing

- [x] `make test` passes (`go test -race -cover ./...`)
- [x] New/changed code has corresponding test cases in `*_test.go`
- [ ] If OCI-calling code was changed, manual integration testing completed

**Test details:**
- Go version: go1.26.1
- Test environment: local

## Checklist

- [x] `make lint` passes
- [x] Self-review completed
- [ ] Comments added for complex logic
- [x] Documentation updated (CONTRIBUTING.md, README if needed)
- [x] Tests added or updated for all new functionality
- [ ] All CI checks pass