### PR TITLE
security: sign release images with cosign and publish TUF-on-CI verification manifests

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -7,13 +7,15 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
+  TUF_TARGET_REPO: amaanx86/oci-prometheus-sd-proxy-tuf-on-ci
 
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       packages: write
+      id-token: write
 
     steps:
       - name: Checkout repository
@@ -47,6 +49,7 @@ jobs:
             type=raw,value=latest
 
       - name: Build and push Docker image
+        id: build
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -59,3 +62,116 @@ jobs:
             VERSION=${{ steps.version.outputs.version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v4.1.1
+        with:
+          cosign-release: v3.0.6
+
+      - name: Sign published image
+        env:
+          COSIGN_EXPERIMENTAL: "false"
+        run: cosign sign --yes "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}"
+
+      - name: Create release metadata
+        run: |
+          cat > release-metadata.json <<EOF
+          {
+            "version": "${{ steps.version.outputs.version }}",
+            "tag": "${{ github.event.release.tag_name }}",
+            "image": "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}",
+            "digest": "${{ steps.build.outputs.digest }}",
+            "commit": "${{ github.sha }}",
+            "workflow": "${{ github.workflow }}",
+            "run_id": "${{ github.run_id }}",
+            "run_url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+            "release_url": "${{ github.event.release.html_url }}",
+            "built_at": "$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+          }
+          EOF
+
+      - name: Upload release metadata asset
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload "${{ github.event.release.tag_name }}" release-metadata.json --clobber
+
+      - name: Attest release metadata
+        env:
+          COSIGN_EXPERIMENTAL: "false"
+        run: cosign attest --yes --predicate release-metadata.json --type https://github.com/amaanx86/oci-prometheus-sd-proxy/release-metadata "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}"
+
+      - name: Publish verification manifest to TUF repository
+        id: tuf_publish
+        env:
+          TUF_REPO_TOKEN: ${{ secrets.TUF_REPO_TOKEN }}
+        run: |
+          if [ -z "${TUF_REPO_TOKEN}" ]; then
+            echo "TUF_REPO_TOKEN secret is required to publish release verification metadata to ${TUF_TARGET_REPO}." >&2
+            exit 1
+          fi
+
+          TAG="${{ github.event.release.tag_name }}"
+          VERSION="${{ steps.version.outputs.version }}"
+          DIGEST="${{ steps.build.outputs.digest }}"
+          IMAGE_REF_DIGEST="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${DIGEST}"
+          SAFE_VERSION="$(echo "${VERSION}" | tr '/.+ ' '----')"
+          SAFE_TAG="$(echo "${TAG}" | tr '/' '_')"
+          SIGNING_BRANCH="sign/release-${SAFE_VERSION}-${{ github.run_id }}"
+          WORKDIR="$(mktemp -d)"
+
+          git clone "https://x-access-token:${TUF_REPO_TOKEN}@github.com/${TUF_TARGET_REPO}.git" "${WORKDIR}"
+          cd "${WORKDIR}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "${SIGNING_BRANCH}" origin/main
+
+          TARGET_PATH="targets/oci-prometheus-sd-proxy/releases/${SAFE_TAG}.json"
+          mkdir -p "$(dirname "${TARGET_PATH}")"
+
+          cat > "${TARGET_PATH}" <<EOF
+          {
+            "schema_version": "1.0",
+            "project": "oci-prometheus-sd-proxy",
+            "version": "${VERSION}",
+            "tag": "${TAG}",
+            "image": "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}",
+            "digest": "${DIGEST}",
+            "image_ref_digest": "${IMAGE_REF_DIGEST}",
+            "release_metadata_asset_url": "${{ github.server_url }}/${{ github.repository }}/releases/download/${TAG}/release-metadata.json",
+            "release_url": "${{ github.event.release.html_url }}",
+            "workflow_run_url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+            "cosign_verify_cmd": "cosign verify ${IMAGE_REF_DIGEST}",
+            "cosign_verify_attestation_cmd": "cosign verify-attestation --type https://github.com/amaanx86/oci-prometheus-sd-proxy/release-metadata ${IMAGE_REF_DIGEST}",
+            "created_at": "$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+          }
+          EOF
+
+          git add "${TARGET_PATH}"
+          if git diff --cached --quiet; then
+            echo "No TUF target changes detected for ${TAG}."
+            echo "pushed_branch=" >> "$GITHUB_OUTPUT"
+            echo "target_path=${TARGET_PATH}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          git commit -m "Add release verification manifest for ${TAG}"
+          git push origin "${SIGNING_BRANCH}"
+
+          echo "pushed_branch=${SIGNING_BRANCH}" >> "$GITHUB_OUTPUT"
+          echo "target_path=${TARGET_PATH}" >> "$GITHUB_OUTPUT"
+
+      - name: Summarize TUF publishing
+        if: steps.tuf_publish.outputs.target_path != ''
+        run: |
+          {
+            echo "### TUF metadata publication"
+            echo "- Target repo: ${TUF_TARGET_REPO}"
+            echo "- Manifest path: ${{ steps.tuf_publish.outputs.target_path }}"
+            if [ -n "${{ steps.tuf_publish.outputs.pushed_branch }}" ]; then
+              echo "- Signing branch: ${{ steps.tuf_publish.outputs.pushed_branch }}"
+              echo "- Expected signing event URL: https://github.com/${TUF_TARGET_REPO}/pulls?q=is%3Apr+head%3A${{ steps.tuf_publish.outputs.pushed_branch }}"
+            else
+              echo "- No branch pushed (manifest unchanged)."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.4.0] - 2025-04-10
+## [1.4.1] - 2026-04-11
+
+### Security
+
+- Sign release images with cosign using GitHub Actions OIDC (keyless signing via Sigstore) on every release
+- Attach a `release-metadata.json` attestation to each image recording version, digest, commit, and workflow run URL - verifiable with `cosign verify-attestation`
+- Upload `release-metadata.json` as a GitHub release asset for out-of-band verification
+- Publish a signed release verification manifest to the TUF-on-CI repository (`amaanx86/oci-prometheus-sd-proxy-tuf-on-ci`) on each release, enabling TUF-based trust anchoring for release metadata
+
+### Documentation
+
+- Added `Image Signing and Release Metadata` section to `docs/security.rst` with `cosign verify` and `cosign verify-attestation` commands and OIDC identity constraints
+- Documented TUF-on-CI metadata repository and its role in isolating TUF lifecycle from application source
+
+### CI
+
+- Updated release workflow permissions: added `id-token: write` for OIDC and `contents: write` for release asset uploads
+- Added `TUF_TARGET_REPO` env var and `TUF_REPO_TOKEN` secret usage to release workflow
+
+## [1.4.0] - 2026-04-10
 
 ### Added
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,8 +3,8 @@
 project = "oci-prometheus-sd-proxy"
 copyright = "2026, Amaan Ul Haq Siddiqui"
 author = "Amaan Ul Haq Siddiqui"
-version = "1.3"
-release = "1.3.0"
+version = "1.4"
+release = "1.4.1"
 
 extensions = [
     "myst_parser",  # Markdown support

--- a/docs/security.rst
+++ b/docs/security.rst
@@ -17,6 +17,38 @@ Generate a strong token:
 
     openssl rand -hex 32
 
+Image Signing and Release Metadata
+----------------------------------
+
+Release images published to GHCR are signed with cosign using GitHub Actions OIDC.
+The release workflow also publishes a `release-metadata.json` asset and attaches
+the same metadata as a cosign attestation so you can verify the release inputs
+and build provenance separately from the image signature.
+
+Verify a signed image with:
+
+.. code-block:: bash
+
+    cosign verify ghcr.io/amaanx86/oci-prometheus-sd-proxy:latest \
+      --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+      --certificate-identity-regexp '^https://github.com/amaanx86/oci-prometheus-sd-proxy/.github/workflows/docker-build-push.yml@refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$'
+
+Verify the release metadata attestation with:
+
+.. code-block:: bash
+
+        cosign verify-attestation ghcr.io/amaanx86/oci-prometheus-sd-proxy:latest \
+            --type https://github.com/amaanx86/oci-prometheus-sd-proxy/release-metadata \
+            --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+            --certificate-identity-regexp '^https://github.com/amaanx86/oci-prometheus-sd-proxy/.github/workflows/docker-build-push.yml@refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$'
+
+A separate TUF-on-CI metadata repository is used for release metadata publication:
+
+- `https://github.com/amaanx86/oci-prometheus-sd-proxy-tuf-on-ci`
+
+This keeps TUF metadata lifecycle management isolated from application source code
+while preserving cosign-based image and attestation verification in this repository.
+
 Best Practices
 --------------
 


### PR DESCRIPTION
## Description

Implements keyless image signing for all release builds and sets up a TUF-on-CI metadata repository for trusted release verification.

Closes #31

## Type of Change

- [x] Feature (non-breaking)
- [x] Documentation update

## What changed

**CI - release workflow (`docker-build-push.yml`)**
- Added cosign keyless signing of the published image digest using GitHub Actions OIDC (no long-lived key material)
- Generates a `release-metadata.json` file containing version, digest, commit SHA, and workflow run URL, then attaches it as a cosign attestation and uploads it as a GitHub release asset
- After signing, clones `amaanx86/oci-prometheus-sd-proxy-tuf-on-ci` and pushes a `sign/release-<version>-<run_id>` branch containing the release verification manifest, which triggers the TUF-on-CI signing event workflow
- Added `id-token: write` (OIDC) and `contents: write` (release asset upload) permissions to the release job

**Documentation (`docs/security.rst`)**
- Added "Image Signing and Release Metadata" section with `cosign verify` and `cosign verify-attestation` commands including OIDC issuer and identity constraints
- Documented the TUF-on-CI repository and its purpose of isolating TUF metadata lifecycle from application source

**Changelog**
- Added `[1.4.1] - 2026-04-11` entry covering all of the above

## TUF decision

TUF was evaluated as part of this issue. The decision: use TUF-on-CI as the metadata distribution layer, keeping it in a separate repository (`amaanx86/oci-prometheus-sd-proxy-tuf-on-ci`) rather than embedding TUF tooling in this repository. This keeps the signing workflow and TUF key management lifecycle cleanly separated.

## Testing

- [x] `make test` passes (`go test -race -cover ./...`)
- [x] New/changed code has corresponding test cases in `*_test.go`
- [x] If OCI-calling code was changed, manual integration testing completed

**Test details:**
- Go version: 1.26
- Test environment: local + CI (workflow validated against v1.4.0 release run)

## Checklist

- [x] `make lint` passes
- [x] Self-review completed
- [x] Comments added for complex logic
- [x] Documentation updated (CONTRIBUTING.md, README if needed)
- [x] Tests added or updated for all new functionality
- [x] All CI checks pass