### PR TITLE
chore: update action versions, Dockerfile version arg, and CI workflow summaries

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -20,29 +20,28 @@ jobs:
       digest: ${{ steps.build.outputs.digest }}
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4.0.0
 
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v4
+      - name: Log in to GHCR
+        uses: docker/login-action@v4.1.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract version from release tag
+      - name: Parse version
         id: version
         run: |
           VERSION=${GITHUB_REF#refs/tags/v}
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
-          echo "Building Docker image version: ${VERSION}"
 
-      - name: Extract metadata
+      - name: Extract image metadata
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@v6.0.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -50,9 +49,9 @@ jobs:
             type=semver,pattern={{major}}.{{minor}},value=${{ steps.version.outputs.version }}
             type=raw,value=latest
 
-      - name: Build and push Docker image
+      - name: Build and push
         id: build
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@v7.1.0
         with:
           context: .
           file: ./Dockerfile
@@ -85,7 +84,7 @@ jobs:
           COSIGN_EXPERIMENTAL: "false"
         run: cosign attest --yes --predicate sbom.cyclonedx.json --type cyclonedx "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}"
 
-      - name: Sign published image
+      - name: Sign image
         env:
           COSIGN_EXPERIMENTAL: "false"
         run: cosign sign --yes "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}"
@@ -107,7 +106,7 @@ jobs:
           }
           EOF
 
-      - name: Upload release metadata asset
+      - name: Upload release metadata
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release upload "${{ github.event.release.tag_name }}" release-metadata.json --clobber
@@ -117,14 +116,13 @@ jobs:
           COSIGN_EXPERIMENTAL: "false"
         run: cosign attest --yes --predicate release-metadata.json --type https://github.com/amaanx86/oci-prometheus-sd-proxy/release-metadata "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}"
 
-      - name: Publish verification manifest to TUF repository
+      - name: Publish to TUF signing repository
         id: tuf_publish
         env:
           TUF_REPO_TOKEN: ${{ secrets.TUF_REPO_TOKEN }}
         run: |
           if [ -z "${TUF_REPO_TOKEN}" ]; then
-            echo "TUF_REPO_TOKEN secret is required to publish release verification metadata to ${TUF_TARGET_REPO}." >&2
-            exit 1
+            echo "::error::TUF_REPO_TOKEN is required" && exit 1
           fi
 
           TAG="${{ github.event.release.tag_name }}"
@@ -135,16 +133,19 @@ jobs:
           SAFE_TAG="$(echo "${TAG}" | tr '/' '_')"
           SIGNING_BRANCH="sign/release-${SAFE_VERSION}-${{ github.run_id }}"
           WORKDIR="$(mktemp -d)"
+          WORKFLOW_REF="https://github.com/${{ github.repository }}/.github/workflows/docker-build-push.yml@refs/tags/${TAG}"
+          OIDC_ISSUER="https://token.actions.githubusercontent.com"
 
           git clone "https://x-access-token:${TUF_REPO_TOKEN}@github.com/${TUF_TARGET_REPO}.git" "${WORKDIR}"
           cd "${WORKDIR}"
-
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git checkout -b "${SIGNING_BRANCH}" origin/main
 
           TARGET_PATH="targets/oci-prometheus-sd-proxy/releases/${SAFE_TAG}.json"
           mkdir -p "$(dirname "${TARGET_PATH}")"
+
+          python3 -m pip install "tuf>=5.0.0,<7.0.0" --quiet
 
           cat > "${TARGET_PATH}" <<EOF
           {
@@ -158,15 +159,35 @@ jobs:
             "release_metadata_asset_url": "${{ github.server_url }}/${{ github.repository }}/releases/download/${TAG}/release-metadata.json",
             "release_url": "${{ github.event.release.html_url }}",
             "workflow_run_url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
-            "cosign_verify_cmd": "cosign verify ${IMAGE_REF_DIGEST}",
-            "cosign_verify_attestation_cmd": "cosign verify-attestation --type https://github.com/amaanx86/oci-prometheus-sd-proxy/release-metadata ${IMAGE_REF_DIGEST}",
+            "cosign_verify_cmd": "cosign verify --certificate-identity=${WORKFLOW_REF} --certificate-oidc-issuer=${OIDC_ISSUER} ${IMAGE_REF_DIGEST}",
+            "cosign_verify_attestation_cmd": "cosign verify-attestation --certificate-identity=${WORKFLOW_REF} --certificate-oidc-issuer=${OIDC_ISSUER} --type https://github.com/amaanx86/oci-prometheus-sd-proxy/release-metadata ${IMAGE_REF_DIGEST}",
             "created_at": "$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
           }
           EOF
 
-          git add "${TARGET_PATH}"
+          export TUF_TARGET_KEY="oci-prometheus-sd-proxy/releases/${SAFE_TAG}.json"
+          export TUF_TARGET_FILE="${TARGET_PATH}"
+          export TUF_METADATA_FILE="metadata/targets.json"
+          python3 -c "
+          import os
+          from tuf.api.metadata import Metadata, TargetFile
+          key   = os.environ['TUF_TARGET_KEY']
+          fpath = os.environ['TUF_TARGET_FILE']
+          mpath = os.environ['TUF_METADATA_FILE']
+          md = Metadata.from_file(mpath)
+          md.signed.targets[key] = TargetFile.from_file(key, fpath)
+          md.signed.version += 1
+          md.signatures.clear()
+          md.to_file(mpath)
+          tf = md.signed.targets[key]
+          sha256 = tf.hashes.get('sha256', 'N/A')
+          print(f'targets.json v{md.signed.version}: registered {key}')
+          print(f'  sha256: {sha256}')
+          print(f'  length: {tf.length} bytes')
+          "
+
+          git add "${TARGET_PATH}" metadata/targets.json
           if git diff --cached --quiet; then
-            echo "No TUF target changes detected for ${TAG}."
             echo "pushed_branch=" >> "$GITHUB_OUTPUT"
             echo "target_path=${TARGET_PATH}" >> "$GITHUB_OUTPUT"
             exit 0
@@ -178,18 +199,17 @@ jobs:
           echo "pushed_branch=${SIGNING_BRANCH}" >> "$GITHUB_OUTPUT"
           echo "target_path=${TARGET_PATH}" >> "$GITHUB_OUTPUT"
 
-      - name: Summarize TUF publishing
+      - name: Job summary
         if: steps.tuf_publish.outputs.target_path != ''
         run: |
           {
-            echo "### TUF metadata publication"
-            echo "- Target repo: ${TUF_TARGET_REPO}"
-            echo "- Manifest path: ${{ steps.tuf_publish.outputs.target_path }}"
+            echo "### Release artifacts"
+            echo "| | |"
+            echo "|---|---|"
+            echo "| Image | \`${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}\` |"
+            echo "| TUF manifest | \`${{ steps.tuf_publish.outputs.target_path }}\` |"
             if [ -n "${{ steps.tuf_publish.outputs.pushed_branch }}" ]; then
-              echo "- Signing branch: ${{ steps.tuf_publish.outputs.pushed_branch }}"
-              echo "- Expected signing event URL: https://github.com/${TUF_TARGET_REPO}/pulls?q=is%3Apr+head%3A${{ steps.tuf_publish.outputs.pushed_branch }}"
-            else
-              echo "- No branch pushed (manifest unchanged)."
+              echo "| Signing PR | https://github.com/${TUF_TARGET_REPO}/pulls |"
             fi
           } >> "$GITHUB_STEP_SUMMARY"
 

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -21,10 +21,10 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@v6.4.0
         with:
           go-version: '1.26.x'
           cache: true
@@ -39,10 +39,10 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@v6.4.0
         with:
           go-version: '1.26.x'
           cache: true

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -11,10 +11,10 @@ jobs:
     name: Trivy Vulnerability Scan
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@v0.35.0
         with:
           scan-type: 'fs'
           scan-ref: '.'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.2] - 2026-04-12
+
+### Fixed
+
+- TUF release manifests were not being registered as TUF targets - `metadata/targets.json` was never updated by the release workflow, so `targets.json` always had an empty target list and a TUF client could not verify any release manifest through the TUF chain
+- Signing event PRs became mergeable immediately without offline maintainer signing because no metadata change was present on the signing branch, so the existing signature on `targets.json` satisfied the threshold check without any new signing required
+- `cosign verify` and `cosign verify-attestation` commands in release verification manifests were missing `--certificate-identity` and `--certificate-oidc-issuer` flags, meaning verification would pass for any Sigstore signer rather than being pinned to the release workflow identity
+- Redeclared `ARG VERSION` in the final Dockerfile stage to resolve undefined variable warning on `LABEL org.opencontainers.image.version`
+
+### CI
+
+- Release workflow now uses `python-tuf` to add the release manifest SHA-256 hash and length to `metadata/targets.json` and clear its signatures before pushing to the signing branch, ensuring the signing-event action requires a fresh offline signature from the maintainer before the PR can be merged
+- Bumped `actions/checkout` from `v4` to `v6.0.2` across all workflows
+- Bumped `docker/setup-buildx-action` from `v3` to `v4.0.0`
+- Bumped `docker/login-action` from `v4` to `v4.1.0`
+- Bumped `docker/metadata-action` from `v6` to `v6.0.0`
+- Bumped `docker/build-push-action` from `v7` to `v7.1.0`
+- Bumped `actions/setup-go` from `v6` to `v6.4.0`
+- Pinned `aquasecurity/trivy-action` from `@master` to `v0.35.0`
+
 ## [1.4.1] - 2026-04-11
 
 ### Security
@@ -207,7 +227,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - GitHub Actions CI/CD for testing and Docker image building
   - CodeQL security scanning
 
-[Unreleased]: https://github.com/amaanx86/oci-prometheus-sd-proxy/compare/v1.4.1...HEAD
+[Unreleased]: https://github.com/amaanx86/oci-prometheus-sd-proxy/compare/v1.4.2...HEAD
+[1.4.2]: https://github.com/amaanx86/oci-prometheus-sd-proxy/compare/v1.4.1...v1.4.2
 [1.4.1]: https://github.com/amaanx86/oci-prometheus-sd-proxy/compare/v1.4.0...v1.4.1
 [1.4.0]: https://github.com/amaanx86/oci-prometheus-sd-proxy/compare/v1.3.0...v1.4.0
 [1.3.0]: https://github.com/amaanx86/oci-prometheus-sd-proxy/compare/v1.2.0...v1.3.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,8 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
 
 FROM gcr.io/distroless/static-debian12:nonroot
 
+ARG VERSION=dev
+
 # Metadata labels
 LABEL org.opencontainers.image.title="oci-prometheus-sd-proxy" \
       org.opencontainers.image.description="Prometheus HTTP Service Discovery proxy for Oracle Cloud Infrastructure" \

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # oci-prometheus-sd-proxy
 
-[![Go Report Card](https://goreportcard.com/badge/github.com/amaanx86/oci-prometheus-sd-proxy)](https://goreportcard.com/report/github.com/amaanx86/oci-prometheus-sd-proxy)
 [![GitHub Release](https://img.shields.io/github/v/release/amaanx86/oci-prometheus-sd-proxy)](https://github.com/amaanx86/oci-prometheus-sd-proxy/releases)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+[![Go Report Card](https://goreportcard.com/badge/github.com/amaanx86/oci-prometheus-sd-proxy)](https://goreportcard.com/report/github.com/amaanx86/oci-prometheus-sd-proxy)
 [![Docker Image](https://img.shields.io/badge/Docker-ghcr.io-blue?logo=docker)](https://github.com/amaanx86/oci-prometheus-sd-proxy/pkgs/container/oci-prometheus-sd-proxy)
-[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12388/badge)](https://www.bestpractices.dev/projects/12388)
 [![SLSA 3](https://slsa.dev/images/gh-badge-level3.svg)](https://slsa.dev)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12388/badge)](https://www.bestpractices.dev/projects/12388)
 
 <img width="469" height="277" alt="OCI Prometheus SD Proxy" src="https://github.com/user-attachments/assets/333a7c32-93bd-4ad9-aea3-aea2d6a66a65" />
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -4,7 +4,7 @@ project = "oci-prometheus-sd-proxy"
 copyright = "2026, Amaan Ul Haq Siddiqui"
 author = "Amaan Ul Haq Siddiqui"
 version = "1.4"
-release = "1.4.1"
+release = "1.4.2"
 
 extensions = [
     "myst_parser",  # Markdown support

--- a/docs/releasing.rst
+++ b/docs/releasing.rst
@@ -3,11 +3,6 @@ Release Process
 
 This document covers how to cut a release, how image signing works, and how a new maintainer can be onboarded as a TUF signer.
 
-.. contents::
-   :local:
-   :depth: 2
-
-
 Overview
 --------
 


### PR DESCRIPTION
## Description

Update GitHub Actions versions to latest to fix Node.js 20 deprecation warnings, add VERSION arg to final Dockerfile stage to prevent undefined variable warnings, and improve TUF publishing workflow summary format in CI.

Relates to the TUF signing fix: when a release is published and CI pushes a signing event branch, the targets.json must be updated as part of the signing commit to ensure the release manifest is properly registered as a TUF target with hash commitment, not just a file in the repo.

Fixes #34
Fixes https://github.com/amaanx86/oci-prometheus-sd-proxy-tuf-on-ci/issues/7

## Type of Change

- [x] Chore/maintenance (non-breaking)

## Testing

- [x] `make lint` passes
- [x] All CI checks pass

## Checklist

- [x] `make lint` passes
- [x] Self-review completed
- [x] All CI checks pass