### PR TITLE
docs: expand release verification and supply chain security coverage

### DIFF
--- a/docs/releasing.rst
+++ b/docs/releasing.rst
@@ -55,10 +55,12 @@ Paste the relevant ``CHANGELOG.md`` section directly into ``--notes``. Include t
 The workflow will:
 
 - Build a multi-arch image (``linux/amd64``, ``linux/arm64``) and push to GHCR
+- Generate a CycloneDX SBOM via ``anchore/sbom-action`` and attach it as a cosign attestation (``--type cyclonedx``); also uploaded as a release asset
 - Sign the image digest with cosign using GitHub Actions OIDC (keyless)
-- Generate ``release-metadata.json`` and attach it as a cosign attestation
+- Generate ``release-metadata.json`` (digest, commit, tag, build timestamp) and attach it as a cosign attestation under the project-specific predicate type
 - Upload ``release-metadata.json`` as a release asset
 - Push a ``sign/release-1-5-0-<run_id>`` branch to the TUF repository
+- Generate SLSA L3 build provenance via ``slsa-github-generator`` in a separate isolated job with its own OIDC identity
 
 3. Sign the TUF targets metadata
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -95,27 +97,86 @@ Once the ``TUF-on-CI signing event`` check passes, merge the PR. The ``online-si
       --repo amaanx86/oci-prometheus-sd-proxy-tuf-on-ci
 
 
-Image signing and verification
--------------------------------
+Verifying a release
+--------------------
 
-All release images are signed keylessly using `cosign <https://docs.sigstore.dev/cosign/overview/>`_ with GitHub Actions OIDC. No private key material is stored anywhere.
+Every release produces four independently verifiable artifacts: an image signature, a CycloneDX SBOM attestation, a release-metadata attestation, and SLSA L3 build provenance. A TUF metadata chain separately records the authorised release digest and can be inspected directly at https://github.com/amaanx86/oci-prometheus-sd-proxy-tuf-on-ci. All verification uses the image digest rather than the tag; the tag is a mutable pointer but the digest is what signatures actually cover.
 
-Verify a signed image::
+Tools required: ``cosign`` (`install <https://docs.sigstore.dev/cosign/system_config/installation/>`_), ``slsa-verifier`` (`install <https://github.com/slsa-framework/slsa-verifier#installation>`_), and ``python3``.
 
-    cosign verify ghcr.io/amaanx86/oci-prometheus-sd-proxy:<version> \
+Step 0: resolve the digest
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+All commands below require the image digest. Resolve it once and reuse it::
+
+    DIGEST=$(cosign verify \
+      --certificate-identity \
+        "https://github.com/amaanx86/oci-prometheus-sd-proxy/.github/workflows/docker-build-push.yml@refs/tags/v<version>" \
       --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-      --certificate-identity-regexp \
-        '^https://github.com/amaanx86/oci-prometheus-sd-proxy/.github/workflows/docker-build-push.yml@refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$'
+      ghcr.io/amaanx86/oci-prometheus-sd-proxy:<version> 2>/dev/null \
+      | python3 -c "
+    import json, sys
+    records = json.load(sys.stdin)
+    print(list({r['critical']['image']['docker-manifest-digest'] for r in records})[0])
+    ")
 
-Verify the release metadata attestation::
+    IMAGE="ghcr.io/amaanx86/oci-prometheus-sd-proxy@${DIGEST}"
 
-    cosign verify-attestation \
-      --type https://github.com/amaanx86/oci-prometheus-sd-proxy/release-metadata \
+Step 1: image signature
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Verifies that the image digest was signed by the ``docker-build-push.yml`` workflow for this exact tag, with the event recorded in the Rekor transparency log::
+
+    cosign verify "${IMAGE}" \
+      --certificate-identity \
+        "https://github.com/amaanx86/oci-prometheus-sd-proxy/.github/workflows/docker-build-push.yml@refs/tags/v<version>" \
+      --certificate-oidc-issuer https://token.actions.githubusercontent.com
+
+Step 2: SBOM attestation
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Verifies the CycloneDX SBOM attestation. The SBOM payload is printed to stdout on success (pipe to ``| python3 -m json.tool`` to read it)::
+
+    cosign verify-attestation "${IMAGE}" \
+      --certificate-identity \
+        "https://github.com/amaanx86/oci-prometheus-sd-proxy/.github/workflows/docker-build-push.yml@refs/tags/v<version>" \
       --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-      --certificate-identity-regexp \
-        '^https://github.com/amaanx86/oci-prometheus-sd-proxy/.github/workflows/docker-build-push.yml@refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$' \
-      ghcr.io/amaanx86/oci-prometheus-sd-proxy:<version>
+      --type cyclonedx \
+      > /dev/null
 
+Step 3: release-metadata attestation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Verifies the in-toto attestation containing the image digest, source commit, release tag, and build timestamp::
+
+    cosign verify-attestation "${IMAGE}" \
+      --certificate-identity \
+        "https://github.com/amaanx86/oci-prometheus-sd-proxy/.github/workflows/docker-build-push.yml@refs/tags/v<version>" \
+      --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+      --type "https://github.com/amaanx86/oci-prometheus-sd-proxy/release-metadata" \
+      | python3 -c "
+    import json, sys, base64
+    e = json.load(sys.stdin)
+    p = e['payload']; p += '=' * (-len(p) % 4)
+    stmt = json.loads(base64.b64decode(p))
+    print(json.dumps(stmt['predicate'], indent=2))
+    "
+
+Step 4: SLSA L3 provenance
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Verifies that the image was built by the ``slsa-github-generator`` trusted builder in an isolated job from the exact source commit. ``slsa-verifier`` requires a digest reference - it rejects mutable tags by design::
+
+    slsa-verifier verify-image "${IMAGE}" \
+      --source-uri "github.com/amaanx86/oci-prometheus-sd-proxy" \
+      --source-tag "v<version>"
+
+A passing result prints the verified builder identity and the source commit::
+
+    Verified build using builder "https://github.com/slsa-framework/slsa-github-generator/
+      .github/workflows/generator_container_slsa3.yml@refs/tags/v2.0.0"
+    at commit <sha>
+    PASSED: SLSA verification passed
 
 TUF signing keys
 -----------------

--- a/docs/security.rst
+++ b/docs/security.rst
@@ -17,37 +17,67 @@ Generate a strong token:
 
     openssl rand -hex 32
 
-Image Signing and Release Metadata
-----------------------------------
+Supply Chain Security
+---------------------
 
-Release images published to GHCR are signed with cosign using GitHub Actions OIDC.
-The release workflow also publishes a `release-metadata.json` asset and attaches
-the same metadata as a cosign attestation so you can verify the release inputs
-and build provenance separately from the image signature.
+Every release image is signed and attested through a fully keyless pipeline - no
+long-lived private keys exist anywhere. The pipeline produces four independently
+verifiable artifacts. Full verification commands are documented in
+:doc:`releasing`.
 
-Verify a signed image with:
+**What is signed**
+
+- Image signature via cosign (GitHub Actions OIDC, recorded in Rekor)
+- CycloneDX SBOM attached as a cosign attestation (``--type cyclonedx``)
+- Release-metadata attestation (digest, source commit, build timestamp)
+- SLSA L3 build provenance via ``slsa-github-generator`` in an isolated job
+- TUF metadata chain published to GitHub Pages via ``tuf-on-ci``
+
+**Verifying an image before deployment**
+
+All verification uses the image digest, not the tag. Resolve it first:
 
 .. code-block:: bash
 
-    cosign verify ghcr.io/amaanx86/oci-prometheus-sd-proxy:latest \
+    DIGEST=$(cosign verify \
+      --certificate-identity \
+        "https://github.com/amaanx86/oci-prometheus-sd-proxy/.github/workflows/docker-build-push.yml@refs/tags/v<version>" \
       --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-      --certificate-identity-regexp '^https://github.com/amaanx86/oci-prometheus-sd-proxy/.github/workflows/docker-build-push.yml@refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$'
+      ghcr.io/amaanx86/oci-prometheus-sd-proxy:<version> 2>/dev/null \
+      | python3 -c "
+    import json, sys
+    records = json.load(sys.stdin)
+    print(list({r['critical']['image']['docker-manifest-digest'] for r in records})[0])
+    ")
 
-Verify the release metadata attestation with:
+    IMAGE="ghcr.io/amaanx86/oci-prometheus-sd-proxy@${DIGEST}"
+
+Image signature:
 
 .. code-block:: bash
 
-        cosign verify-attestation ghcr.io/amaanx86/oci-prometheus-sd-proxy:latest \
-            --type https://github.com/amaanx86/oci-prometheus-sd-proxy/release-metadata \
-            --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-            --certificate-identity-regexp '^https://github.com/amaanx86/oci-prometheus-sd-proxy/.github/workflows/docker-build-push.yml@refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$'
+    cosign verify "${IMAGE}" \
+      --certificate-identity \
+        "https://github.com/amaanx86/oci-prometheus-sd-proxy/.github/workflows/docker-build-push.yml@refs/tags/v<version>" \
+      --certificate-oidc-issuer https://token.actions.githubusercontent.com
 
-A separate TUF-on-CI metadata repository is used for release metadata publication:
+SLSA L3 provenance (requires ``slsa-verifier``):
 
-- `https://github.com/amaanx86/oci-prometheus-sd-proxy-tuf-on-ci`
+.. code-block:: bash
 
-This keeps TUF metadata lifecycle management isolated from application source code
-while preserving cosign-based image and attestation verification in this repository.
+    slsa-verifier verify-image "${IMAGE}" \
+      --source-uri "github.com/amaanx86/oci-prometheus-sd-proxy" \
+      --source-tag "v<version>"
+
+See :doc:`releasing` for SBOM attestation and release-metadata attestation verification.
+
+**TUF metadata repository**
+
+Release manifests are published independently at
+https://github.com/amaanx86/oci-prometheus-sd-proxy-tuf-on-ci.
+This keeps TUF lifecycle management (key rotation, metadata expiry) isolated
+from the application repository. The signed metadata is served via GitHub Pages at
+https://amaanx86.github.io/oci-prometheus-sd-proxy-tuf-on-ci/metadata/.
 
 Best Practices
 --------------


### PR DESCRIPTION
## Description

Expands `releasing.rst` and `security.rst` to fully document the release verification pipeline. The previous docs were missing most of the supply chain artifacts, had a broken regexp that excluded RC/pre-release tags, and included a TUF ngclient snippet that doesn't work with tuf-on-ci's Sigstore OIDC keys.

## Type of Change

- [ ] Bug fix (non-breaking)
- [ ] Feature (non-breaking)
- [ ] Breaking change
- [x] Documentation update

## Testing

- [x] `make test` passes (`go test -race -cover ./...`)
- [ ] New/changed code has corresponding test cases in `*_test.go`
- [ ] If OCI-calling code was changed, manual integration testing completed

**Test details:**
All verification commands in the updated docs were manually tested against the `v1.4.2-rc` image and confirmed passing:
- `cosign verify` image signature
- `cosign verify-attestation --type cyclonedx` SBOM attestation
- `cosign verify-attestation --type <release-metadata-url>` with payload decode
- `slsa-verifier verify-image` SLSA L3 provenance

## Checklist

- [ ] `make lint` passes
- [x] Self-review completed
- [ ] Comments added for complex logic
- [x] Documentation updated (CONTRIBUTING.md, README if needed)
- [ ] Tests added or updated for all new functionality
- [ ] All CI checks pass