### PR TITLE
feat: add instance_principal auth_type for OCI tenancies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.0] - 2026-04-18
+
+### Added
+
+- Instance principal authentication support for OCI tenancies. Set `auth_type: instance_principal` on a tenancy to authenticate via OCI IMDS instead of static user/key credentials. No `user_id`, `fingerprint`, or `private_key_path` fields required. Useful when the proxy runs directly on an OCI compute instance with a dynamic group + IAM policy granting read access.
+- `auth_type` field on tenancy config accepting `api_key` (default, existing behaviour unchanged) or `instance_principal`. Unknown values are rejected at startup with a clear error.
+
+### Tests
+
+- Added `TestValidate_InstancePrincipalAuth`: asserts instance principal tenancies pass validation without credential fields.
+- Added `TestValidate_InstancePrincipalStillRequiresRegionAndTenancyID`: asserts `name`, `tenancy_id`, and `region` remain required for instance principal tenancies.
+- Added `TestValidate_UnknownAuthType`: asserts an unrecognised `auth_type` value is rejected at startup.
+
+### Documentation
+
+- `docs/installation.rst`: added Option B section with step-by-step dynamic group creation, instance principal IAM policy statements, and a note that policies must be at tenancy root level for compartment auto-discovery.
+- `docs/configuration.rst`: documented `auth_type` field and clarified which credential fields are conditional on auth method.
+- `README.md`: updated OCI IAM Policy section to show both API key and instance principal policy blocks.
+
 ## [1.4.2] - 2026-04-12
 
 ### Fixed
@@ -227,7 +246,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - GitHub Actions CI/CD for testing and Docker image building
   - CodeQL security scanning
 
-[Unreleased]: https://github.com/amaanx86/oci-prometheus-sd-proxy/compare/v1.4.2...HEAD
+[Unreleased]: https://github.com/amaanx86/oci-prometheus-sd-proxy/compare/v1.5.0...HEAD
+[1.5.0]: https://github.com/amaanx86/oci-prometheus-sd-proxy/compare/v1.4.2...v1.5.0
 [1.4.2]: https://github.com/amaanx86/oci-prometheus-sd-proxy/compare/v1.4.1...v1.4.2
 [1.4.1]: https://github.com/amaanx86/oci-prometheus-sd-proxy/compare/v1.4.0...v1.4.1
 [1.4.0]: https://github.com/amaanx86/oci-prometheus-sd-proxy/compare/v1.3.0...v1.4.0

--- a/README.md
+++ b/README.md
@@ -71,7 +71,9 @@ scrape_configs:
 
 ## OCI IAM Policy
 
-The OCI user or group used by this service requires the following IAM policies in each tenancy:
+Two authentication methods are supported via `auth_type` in `config.yaml`.
+
+**API key auth** (default - works anywhere):
 
 ```
 Allow group <group-name> to read instances in tenancy
@@ -81,7 +83,17 @@ Allow group <group-name> to read vnics in tenancy
 Allow group <group-name> to read tag-namespaces in tenancy
 ```
 
-Replace `<group-name>` with the OCI group that contains the API key user. These policies cover compartment auto-discovery, instance listing, VNIC resolution, and tag-based filtering. Missing any of these will result in `NotAuthorizedOrNotFound` errors in the logs.
+**Instance principal auth** (proxy runs on OCI compute - no credentials needed):
+
+```
+Allow dynamic-group <dynamic-group-name> to read instances in tenancy
+Allow dynamic-group <dynamic-group-name> to read compartments in tenancy
+Allow dynamic-group <dynamic-group-name> to read vnic-attachments in tenancy
+Allow dynamic-group <dynamic-group-name> to read vnics in tenancy
+Allow dynamic-group <dynamic-group-name> to read tag-namespaces in tenancy
+```
+
+These five permissions cover all API calls the proxy makes. Missing any will result in `NotAuthorizedOrNotFound` errors in the logs. See the [full installation docs](https://oci-prometheus-sd-proxy.readthedocs.io/) for dynamic group setup and policy scoping requirements.
 
 ## Full Documentation
 

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -16,7 +16,9 @@ discovery:
   rate_limit_rps: 10.0            # max OCI API requests per second per tenancy
 
 tenancies:
+  # --- Option A: API key auth (static credentials, works anywhere) ---
   - name: my-tenancy
+    auth_type: api_key            # default; can be omitted
     region: me-jeddah-1         # OCI region code
     tenancy_id: ocid1.tenancy.oc1..xxxxxx
     user_id: ocid1.user.oc1..xxxxxx
@@ -29,12 +31,11 @@ tenancies:
     # Or explicitly list compartment OCIDs to scan only those
     compartments: []
 
-  # Optional: add more tenancies
-  # - name: another-tenancy
+  # --- Option B: Instance principal auth (proxy runs on OCI compute) ---
+  # No user/key credentials needed - the instance identity is used automatically.
+  # Requires a dynamic group + IAM policy granting the instance read access.
+  # - name: my-tenancy-instance-principal
+  #   auth_type: instance_principal
   #   region: us-ashburn-1
   #   tenancy_id: ocid1.tenancy.oc1..yyyyyy
-  #   user_id: ocid1.user.oc1..yyyyyy
-  #   fingerprint: "11:22:33:44:55:66:77:88:99:aa:bb:cc:dd:ee:ff:00"
-  #   private_key_path: /etc/oci-sd/keys/api_key_2.pem
-  #   passphrase: ""
   #   compartments: []

--- a/deploy/docker/config.yaml.example
+++ b/deploy/docker/config.yaml.example
@@ -16,7 +16,9 @@ discovery:
   rate_limit_rps: 10.0            # max OCI API requests per second per tenancy
 
 tenancies:
+  # --- Option A: API key auth (static credentials, works anywhere) ---
   - name: my-tenancy
+    auth_type: api_key            # default; can be omitted
     region: me-jeddah-1         # OCI region code
     tenancy_id: ocid1.tenancy.oc1..xxxxxx
     user_id: ocid1.user.oc1..xxxxxx
@@ -29,12 +31,11 @@ tenancies:
     # Or explicitly list compartment OCIDs to scan only those
     compartments: []
 
-  # Optional: add more tenancies
-  # - name: another-tenancy
+  # --- Option B: Instance principal auth (proxy runs on OCI compute) ---
+  # No user/key credentials needed - the instance identity is used automatically.
+  # Requires a dynamic group + IAM policy granting the instance read access.
+  # - name: my-tenancy-instance-principal
+  #   auth_type: instance_principal
   #   region: us-ashburn-1
   #   tenancy_id: ocid1.tenancy.oc1..yyyyyy
-  #   user_id: ocid1.user.oc1..yyyyyy
-  #   fingerprint: "11:22:33:44:55:66:77:88:99:aa:bb:cc:dd:ee:ff:00"
-  #   private_key_path: /etc/oci-sd/keys/api_key_2.pem
-  #   passphrase: ""
   #   compartments: []

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,8 +3,8 @@
 project = "oci-prometheus-sd-proxy"
 copyright = "2026, Amaan Ul Haq Siddiqui"
 author = "Amaan Ul Haq Siddiqui"
-version = "1.4"
-release = "1.4.2"
+version = "1.5"
+release = "1.5.0"
 
 extensions = [
     "myst_parser",  # Markdown support

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -121,17 +121,23 @@ Fields
 **tenancies[].tenancy_id**
     Tenancy OCID
 
+**tenancies[].auth_type**
+    Authentication method. One of:
+
+    - ``api_key`` (default) - static user credentials; requires ``user_id``, ``fingerprint``, and ``private_key_path``
+    - ``instance_principal`` - authenticates via OCI IMDS; no credential fields needed. Only valid when the proxy runs on an OCI compute instance with a dynamic group and IAM policy granting read access. See :doc:`installation` for setup steps.
+
 **tenancies[].user_id**
-    User OCID for API authentication
+    User OCID for API authentication. Required when ``auth_type`` is ``api_key``.
 
 **tenancies[].fingerprint**
-    API key fingerprint
+    API key fingerprint. Required when ``auth_type`` is ``api_key``.
 
 **tenancies[].private_key_path**
-    Path to unencrypted PEM private key
+    Path to unencrypted PEM private key. Required when ``auth_type`` is ``api_key``.
 
 **tenancies[].passphrase**
-    Passphrase for encrypted keys (leave empty for unencrypted)
+    Passphrase for encrypted keys (leave empty for unencrypted). Only used with ``api_key`` auth.
 
 **tenancies[].compartments**
     List of compartment OCIDs to scan. Leave empty ``[]`` to auto-discover all compartments.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -57,10 +57,12 @@ Before running the service:
    - Key: ``monitoring``
    - Value: ``enabled``
 
-2. **Create API credentials** for each OCI tenancy:
+2. **Grant OCI permissions** - choose one of two authentication methods:
 
-   - Generate an API key pair in OCI Console under **Identity > Users > API Keys**
-   - Add the user to an OCI group and attach the following IAM policies to that group in each tenancy:
+   .. rubric:: Option A: API key auth (works anywhere)
+
+   Generate an API key pair in OCI Console under **Identity > Users > API Keys**.
+   Add the user to an OCI group and attach the following IAM policies to that group in each tenancy:
 
    .. code-block:: text
 
@@ -70,7 +72,47 @@ Before running the service:
        Allow group <group-name> to read vnics in tenancy
        Allow group <group-name> to read tag-namespaces in tenancy
 
-   Replace ``<group-name>`` with the OCI group containing your API key user. These five policies cover all API calls the proxy makes:
+   Replace ``<group-name>`` with the OCI group containing your API key user.
+
+   .. rubric:: Option B: Instance principal auth (proxy runs on OCI compute)
+
+   No API key is needed. The compute instance authenticates using its own identity via OCI IMDS.
+
+   **Step 1** - Create a dynamic group that matches the instance running the proxy.
+   In OCI Console go to **Identity > Dynamic Groups > Create Dynamic Group**:
+
+   .. code-block:: text
+
+       All {instance.id = '<your-instance-ocid>'}
+
+   Or to match any instance in a compartment:
+
+   .. code-block:: text
+
+       All {instance.compartment.id = '<compartment-ocid>'}
+
+   **Step 2** - Create IAM policies granting the dynamic group read access.
+   In OCI Console go to **Identity > Policies > Create Policy** at the tenancy (root) level:
+
+   .. code-block:: text
+
+       Allow dynamic-group <dynamic-group-name> to read instances in tenancy
+       Allow dynamic-group <dynamic-group-name> to read compartments in tenancy
+       Allow dynamic-group <dynamic-group-name> to read vnic-attachments in tenancy
+       Allow dynamic-group <dynamic-group-name> to read vnics in tenancy
+       Allow dynamic-group <dynamic-group-name> to read tag-namespaces in tenancy
+
+   Replace ``<dynamic-group-name>`` with the dynamic group created in Step 1.
+
+   .. note::
+
+      Policies for instance principals must be created at the **tenancy (root) level**, not at the compartment level, for ``ListCompartments`` to traverse the full compartment tree.
+
+   **Step 3** - Set ``auth_type: instance_principal`` in ``config.yaml`` (see :doc:`configuration`).
+
+   ---
+
+   These five permissions cover all API calls the proxy makes regardless of auth method:
 
    .. list-table::
       :header-rows: 1

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -39,6 +39,7 @@ type TenancyConfig struct {
 	Name           string   `yaml:"name"`
 	Region         string   `yaml:"region"`
 	TenancyID      string   `yaml:"tenancy_id"`
+	AuthType       string   `yaml:"auth_type"` // "api_key" (default) or "instance_principal"
 	UserID         string   `yaml:"user_id"`
 	Fingerprint    string   `yaml:"fingerprint"`
 	PrivateKeyPath string   `yaml:"private_key_path"`
@@ -144,17 +145,24 @@ func (c *Config) validate() error {
 		if t.TenancyID == "" {
 			return fmt.Errorf("tenancy[%d] (%s): tenancy_id is required", i, t.Name)
 		}
-		if t.UserID == "" {
-			return fmt.Errorf("tenancy[%d] (%s): user_id is required", i, t.Name)
-		}
 		if t.Region == "" {
 			return fmt.Errorf("tenancy[%d] (%s): region is required", i, t.Name)
 		}
-		if t.Fingerprint == "" {
-			return fmt.Errorf("tenancy[%d] (%s): fingerprint is required", i, t.Name)
-		}
-		if t.PrivateKeyPath == "" {
-			return fmt.Errorf("tenancy[%d] (%s): private_key_path is required", i, t.Name)
+		switch t.AuthType {
+		case "", "api_key":
+			if t.UserID == "" {
+				return fmt.Errorf("tenancy[%d] (%s): user_id is required for api_key auth", i, t.Name)
+			}
+			if t.Fingerprint == "" {
+				return fmt.Errorf("tenancy[%d] (%s): fingerprint is required for api_key auth", i, t.Name)
+			}
+			if t.PrivateKeyPath == "" {
+				return fmt.Errorf("tenancy[%d] (%s): private_key_path is required for api_key auth", i, t.Name)
+			}
+		case "instance_principal":
+			// no credential fields required - identity comes from IMDS
+		default:
+			return fmt.Errorf("tenancy[%d] (%s): unknown auth_type %q - must be api_key or instance_principal", i, t.Name, t.AuthType)
 		}
 		// Note: empty compartments array is OK - will auto-discover all compartments in tenancy
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -326,6 +326,57 @@ func TestValidate_TenancyRequiredFields(t *testing.T) {
 	}
 }
 
+func TestValidate_InstancePrincipalAuth(t *testing.T) {
+	// instance_principal does not require user_id, fingerprint, or private_key_path
+	cfg := defaults()
+	cfg.Server.Token = "tok"
+	cfg.Tenancies = []TenancyConfig{{
+		Name: "t", Region: "r", TenancyID: "tid",
+		AuthType: "instance_principal",
+	}}
+	if err := cfg.validate(); err != nil {
+		t.Errorf("unexpected error for instance_principal tenancy: %v", err)
+	}
+}
+
+func TestValidate_InstancePrincipalStillRequiresRegionAndTenancyID(t *testing.T) {
+	cases := []struct {
+		name   string
+		mutate func(*TenancyConfig)
+	}{
+		{"missing name", func(c *TenancyConfig) { c.Name = "" }},
+		{"missing tenancy_id", func(c *TenancyConfig) { c.TenancyID = "" }},
+		{"missing region", func(c *TenancyConfig) { c.Region = "" }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tenancy := TenancyConfig{
+				Name: "t", Region: "r", TenancyID: "tid",
+				AuthType: "instance_principal",
+			}
+			tc.mutate(&tenancy)
+			cfg := defaults()
+			cfg.Server.Token = "tok"
+			cfg.Tenancies = []TenancyConfig{tenancy}
+			if err := cfg.validate(); err == nil {
+				t.Errorf("expected validation error for %s", tc.name)
+			}
+		})
+	}
+}
+
+func TestValidate_UnknownAuthType(t *testing.T) {
+	cfg := defaults()
+	cfg.Server.Token = "tok"
+	cfg.Tenancies = []TenancyConfig{{
+		Name: "t", Region: "r", TenancyID: "tid",
+		AuthType: "magic_beans",
+	}}
+	if err := cfg.validate(); err == nil {
+		t.Error("expected validation error for unknown auth_type")
+	}
+}
+
 func TestValidate_ValidConfig(t *testing.T) {
 	c := defaults()
 	c.Server.Token = "tok"

--- a/internal/discovery/oci.go
+++ b/internal/discovery/oci.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/oracle/oci-go-sdk/v65/common"
+	"github.com/oracle/oci-go-sdk/v65/common/auth"
 	"github.com/oracle/oci-go-sdk/v65/core"
 	"github.com/oracle/oci-go-sdk/v65/identity"
 	"golang.org/x/time/rate"
@@ -37,13 +38,17 @@ type tenancyDiscoverer struct {
 	retry   common.RetryPolicy
 }
 
-// discoverTenancy returns all matching target groups from a single OCI tenancy.
-// Errors from individual compartments are logged and skipped rather than failing
-// the entire tenancy, so a partial result is always returned.
-func discoverTenancy(ctx context.Context, cfg *config.Config, tenancy config.TenancyConfig) ([]TargetGroup, tenancyStats, error) {
+// buildConfigProvider returns the appropriate OCI configuration provider based on
+// the tenancy's auth_type. "instance_principal" uses IMDS-based credentials;
+// "api_key" (the default) uses the static user/key credentials from config.
+func buildConfigProvider(tenancy config.TenancyConfig) (common.ConfigurationProvider, error) {
+	if tenancy.AuthType == "instance_principal" {
+		return auth.InstancePrincipalConfigurationProvider()
+	}
+
 	keyContent, err := os.ReadFile(tenancy.PrivateKeyPath)
 	if err != nil {
-		return nil, tenancyStats{}, fmt.Errorf("read private key for tenancy %q: %w", tenancy.Name, err)
+		return nil, fmt.Errorf("read private key: %w", err)
 	}
 
 	var passphrase *string
@@ -51,14 +56,24 @@ func discoverTenancy(ctx context.Context, cfg *config.Config, tenancy config.Ten
 		passphrase = &tenancy.Passphrase
 	}
 
-	provider := common.NewRawConfigurationProvider(
+	return common.NewRawConfigurationProvider(
 		tenancy.TenancyID,
 		tenancy.UserID,
 		tenancy.Region,
 		tenancy.Fingerprint,
 		string(keyContent),
 		passphrase,
-	)
+	), nil
+}
+
+// discoverTenancy returns all matching target groups from a single OCI tenancy.
+// Errors from individual compartments are logged and skipped rather than failing
+// the entire tenancy, so a partial result is always returned.
+func discoverTenancy(ctx context.Context, cfg *config.Config, tenancy config.TenancyConfig) ([]TargetGroup, tenancyStats, error) {
+	provider, err := buildConfigProvider(tenancy)
+	if err != nil {
+		return nil, tenancyStats{}, fmt.Errorf("build config provider for tenancy %q: %w", tenancy.Name, err)
+	}
 
 	computeClient, err := core.NewComputeClientWithConfigurationProvider(provider)
 	if err != nil {


### PR DESCRIPTION
## Description

Adds support for Instance Principal authentication as an alternative to static API key credentials. When `auth_type: instance_principal` is set on a tenancy, the proxy authenticates via OCI IMDS instead of requiring `user_id`, `fingerprint`, and `private_key_path`. This is useful when the proxy runs directly on an OCI compute instance.

Fixes #38

## Type of Change

- [ ] Bug fix (non-breaking)
- [x] Feature (non-breaking)
- [ ] Breaking change
- [ ] Documentation update

## Testing

**New or changed functionality requires automated tests** (see [CONTRIBUTING.md](../CONTRIBUTING.md#testing)).

- [x] `make test` passes (`go test -race -cover ./...`)
- [x] New/changed code has corresponding test cases in `*_test.go`
- [ ] If OCI-calling code was changed, manual integration testing completed

`buildConfigProvider` dispatches on `auth_type` - the instance_principal branch calls `auth.InstancePrincipalConfigurationProvider()` which requires live IMDS and cannot be tested without an OCI compute instance. The surrounding config validation, error propagation, and api_key path are fully covered by the test suite.

New tests added in `internal/config/config_test.go`:
- `TestValidate_InstancePrincipalAuth` - instance_principal tenancy passes validation without credential fields
- `TestValidate_InstancePrincipalStillRequiresRegionAndTenancyID` - name, tenancy_id, region remain required
- `TestValidate_UnknownAuthType` - unknown auth_type values are rejected at startup

**Test details:**
- Go version: 1.26
- Test environment: local

## Checklist

- [x] `make lint` passes
- [x] Self-review completed
- [x] Comments added for complex logic
- [x] Documentation updated (CONTRIBUTING.md, README if needed)
- [x] Tests added or updated for all new functionality
- [ ] All CI checks pass