### PR TITLE
chore: bump version to 1.5.1 and update changelog for oci-go-sdk v65.112.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.1] - 2026-04-21
+
+### Changed
+
+- Bumped `github.com/oracle/oci-go-sdk/v65` from `65.111.0` to `65.112.0`
+
 ## [1.5.0] - 2026-04-18
 
 ### Added
@@ -246,7 +252,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - GitHub Actions CI/CD for testing and Docker image building
   - CodeQL security scanning
 
-[Unreleased]: https://github.com/amaanx86/oci-prometheus-sd-proxy/compare/v1.5.0...HEAD
+[Unreleased]: https://github.com/amaanx86/oci-prometheus-sd-proxy/compare/v1.5.1...HEAD
+[1.5.1]: https://github.com/amaanx86/oci-prometheus-sd-proxy/compare/v1.5.0...v1.5.1
 [1.5.0]: https://github.com/amaanx86/oci-prometheus-sd-proxy/compare/v1.4.2...v1.5.0
 [1.4.2]: https://github.com/amaanx86/oci-prometheus-sd-proxy/compare/v1.4.1...v1.4.2
 [1.4.1]: https://github.com/amaanx86/oci-prometheus-sd-proxy/compare/v1.4.0...v1.4.1

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -4,7 +4,7 @@ project = "oci-prometheus-sd-proxy"
 copyright = "2026, Amaan Ul Haq Siddiqui"
 author = "Amaan Ul Haq Siddiqui"
 version = "1.5"
-release = "1.5.0"
+release = "1.5.1"
 
 extensions = [
     "myst_parser",  # Markdown support


### PR DESCRIPTION
## Description

Bumps `docs/conf.py` release to `1.5.1` and adds a CHANGELOG entry for the `oci-go-sdk` dependency update from `65.111.0` to `65.112.0` that landed via dependabot in #40.

## Type of Change

- [ ] Bug fix (non-breaking)
- [ ] Feature (non-breaking)
- [ ] Breaking change
- [x] Documentation update

## Testing

**New or changed functionality requires automated tests** (see [CONTRIBUTING.md](../CONTRIBUTING.md#testing)).

- [ ] `make test` passes (`go test -race -cover ./...`) - blocked locally, `proxy.golang.org` unreachable; no code changes, CI will verify
- [ ] New/changed code has corresponding test cases in `*_test.go`
- [ ] If OCI-calling code was changed, manual integration testing completed

**Test details:**
- Go version: 1.26.x
- Test environment: CI

## Checklist

- [ ] `make lint` passes - same network block locally; no code changes
- [x] Self-review completed
- [ ] Comments added for complex logic
- [x] Documentation updated (CONTRIBUTING.md, README if needed)
- [ ] Tests added or updated for all new functionality
- [ ] All CI checks pass