### PR TITLE
ci: add workflow_dispatch trigger to go-test workflow

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -1,6 +1,7 @@
 name: Go Test & Lint
 
 on:
+  workflow_dispatch:
   pull_request:
     branches: [main]
     paths-ignore:


### PR DESCRIPTION
## Description

Adds `workflow_dispatch` to the Go Test & Lint workflow so it can be triggered manually from the Actions tab without requiring a code push.

## Type of Change

- [ ] Bug fix (non-breaking)
- [ ] Feature (non-breaking)
- [ ] Breaking change
- [x] Documentation update

## Testing

- [ ] `make test` passes (`go test -race -cover ./...`)
- [ ] New/changed code has corresponding test cases in `*_test.go`
- [ ] If OCI-calling code was changed, manual integration testing completed

**Test details:**
- Go version: 1.26.x
- Test environment: CI

## Checklist

- [x] `make lint` passes
- [x] Self-review completed
- [ ] Comments added for complex logic
- [ ] Documentation updated (CONTRIBUTING.md, README if needed)
- [ ] Tests added or updated for all new functionality
- [ ] All CI checks pass