### PR TITLE
chore: bump docs version to 1.5.2

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -4,7 +4,7 @@ project = "oci-prometheus-sd-proxy"
 copyright = "2026, Amaan Ul Haq Siddiqui"
 author = "Amaan Ul Haq Siddiqui"
 version = "1.5"
-release = "1.5.1"
+release = "1.5.2"
 
 extensions = [
     "myst_parser",  # Markdown support


### PR DESCRIPTION
## Description

Bump `release` version in `docs/conf.py` from 1.5.1 to 1.5.2 to match the latest release.

## Type of Change

- [ ] Bug fix (non-breaking)
- [ ] Feature (non-breaking)
- [ ] Breaking change
- [x] Documentation update

## Testing

- [x] `make test` passes (`go test -race -cover ./...`)
- No code changes, docs config only.

## Checklist

- [x] `make lint` passes
- [x] Self-review completed
- [x] Documentation updated
- [x] All CI checks pass