### PR TITLE
ci: add issue notify workflow to tag maintainer on new issues

### DIFF
--- a/.github/workflows/issue-notify.yml
+++ b/.github/workflows/issue-notify.yml
@@ -1,0 +1,37 @@
+name: Issue Notify
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Comment and tag maintainer
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.BOT_PAT }}
+          script: |
+            const { issue } = context.payload;
+            const opener = issue.user.login;
+            const labels = issue.labels.map(l => `\`${l.name}\``).join(', ') || 'None';
+            const body = [
+              `@amaanx86 A new issue requires your attention.`,
+              '',
+              `| Field | Details |`,
+              `| --- | --- |`,
+              `| **Author** | @${opener} |`,
+              `| **Issue** | #${issue.number} - ${issue.title} |`,
+              `| **Labels** | ${labels} |`,
+              '',
+              'Please review and triage at your earliest convenience.',
+            ].join('\n');
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body,
+            });


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that triggers on new issues
- Comments via `devops-ci-bot` tagging @amaanx86 with issue metadata (author, title, labels)
- Uses `BOT_PAT` repo secret for bot identity

## Prerequisites
- [ ] Add `BOT_PAT` secret (classic PAT from `devops-ci-bot` with `public_repo` scope)

## Test plan
- [ ] Add the `BOT_PAT` secret to repo settings
- [ ] Open a test issue and verify the bot comments with the correct format
- [ ] Verify the comment appears from `devops-ci-bot`, not `github-actions[bot]`