### PR TITLE
ci: add PR auto-labeling based on changed file paths

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,59 @@
+go:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '**/*.go'
+          - 'go.mod'
+          - 'go.sum'
+
+build:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'Makefile'
+
+documentation:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'docs/**'
+          - '*.md'
+
+ci:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '.github/**'
+
+docker:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'Dockerfile'
+          - 'docker-compose*.yml'
+
+config:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'internal/config/**'
+          - 'config.yaml'
+          - '*.yaml'
+          - '!.github/**'
+
+discovery:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'internal/discovery/**'
+
+api:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'internal/handler/**'
+          - 'internal/server/**'
+          - 'internal/middleware/**'
+
+deployment:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'deploy/**'
+
+dependencies:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'go.mod'
+          - 'go.sum'

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,18 @@
+name: PR Labeler
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          repo-token: ${{ secrets.BOT_PAT }}
+          configuration-path: .github/labeler.yml
+          sync-labels: true


### PR DESCRIPTION
## Summary
- Adds `actions/labeler@v5` workflow to auto-label PRs on open/sync based on changed files
- Labels: `go`, `documentation`, `ci`, `docker`, `build`, `config`, `discovery`, `api`, `deployment`, `dependencies`
- Uses `BOT_PAT` so labels are applied by `devops-ci-bot`
- Backfilled labels on all 35 existing merged/open PRs

## Test plan
- [ ] Merge this PR, then open a new test PR and verify labels are auto-applied by `devops-ci-bot`