### PR TITLE
docs: fix contributing and security markdown links

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,7 +13,7 @@ Fixes #(issue)
 
 ## Testing
 
-**New or changed functionality requires automated tests** (see [CONTRIBUTING.md](../CONTRIBUTING.md#testing)).
+**New or changed functionality requires automated tests** (see [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md#testing)).
 
 - [ ] `make test` passes (`go test -race -cover ./...`)
 - [ ] New/changed code has corresponding test cases in `*_test.go`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Security
 
-Found a security vulnerability? Do not open a GitHub issue. See [SECURITY.MD](SECURITY.MD) for responsible disclosure guidelines.
+Found a security vulnerability? Do not open a GitHub issue. See [SECURITY.md](SECURITY.md) for responsible disclosure guidelines.
 
 ## Setup
 


### PR DESCRIPTION
## Description

Fixes two Markdown links in the repository documentation:

- Updates the `SECURITY.md` reference in `CONTRIBUTING.md` to match the actual filename casing.
- Updates the `CONTRIBUTING.md#testing` link in the pull request template so it resolves correctly when rendered in a pull request body. 

Fixes N/A (docs-only)

## Type of Change

- [x] Bug fix (non-breaking) / N/A (docs-only)
- [x] Feature (non-breaking) / N/A (docs-only)
- [x] Breaking change / N/A (docs-only)
- [x] Documentation update

## Testing

**New or changed functionality requires automated tests** (see [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md#testing)).

- [x] `make test` passes (`go test -race -cover ./...`) / N/A (docs-only)
- [x] New/changed code has corresponding test cases in `*_test.go` / N/A (docs-only)
- [x] If OCI-calling code was changed, manual integration testing completed / N/A (docs-only)

**Test details:**
- Go version: N/A (docs-only)
- Test environment: N/A (docs-only)
- Not run; documentation-only change.

## Checklist

- [x] `make lint` passes / N/A (docs-only)
- [x] Self-review completed
- [x] Comments added for complex logic: N/A (docs-only)
- [x] Documentation updated (CONTRIBUTING.md, README if needed)
- [x] Tests added or updated for all new functionality: N/A (docs-only)
- [x] All CI checks pass / N/A (docs-only)