### PR TITLE
fix(ci): use pull_request_target to allow labeler on fork PRs

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,7 +1,7 @@
 name: PR Labeler
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize]
 
 jobs:
@@ -13,6 +13,6 @@ jobs:
     steps:
       - uses: actions/labeler@v6
         with:
-          repo-token: ${{ secrets.BOT_PAT || secrets.GITHUB_TOKEN }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
           configuration-path: .github/labeler.yml
           sync-labels: true


### PR DESCRIPTION
## Description

The PR Labeler workflow was failing on fork pull requests with `Resource not accessible by integration`. The `pull_request` event runs in the fork's context and provides a read-only token that cannot write labels back to the base repository.

Fixes #77

## Type of Change

- [x] Bug fix (non-breaking)
- [ ] Feature (non-breaking)
- [ ] Breaking change
- [ ] Documentation update

## Testing

- [x] `make test` passes (`go test -race -cover ./...`)
- [ ] New/changed code has corresponding test cases in `*_test.go`
- [ ] If OCI-calling code was changed, manual integration testing completed

**Test details:**
- Go version: N/A (workflow-only change)
- Test environment: GitHub Actions

## Checklist

- [x] `make lint` passes
- [x] Self-review completed
- [ ] Comments added for complex logic
- [ ] Documentation updated (CONTRIBUTING.md, README if needed)
- [ ] Tests added or updated for all new functionality
- [ ] All CI checks pass