### PR TITLE
chore(docs): clarify GPG signing subkey behavior in SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -33,6 +33,8 @@ All commits and tags from the maintainer are GPG-signed. You can verify them usi
 | Algorithm | RSA 4096 |
 | Keyserver | https://keyserver.ubuntu.com/pks/lookup?search=amaanulhaq.s%40outlook.com&op=get |
 
+> **Note:** GitHub may display the ID of a signing subkey (e.g. `2BB500FE5A696562`) rather than the primary key ID. Commits and tags may be signed by the documented primary OpenPGP key or by signing subkeys under that primary key. You can confirm a subkey belongs to the primary key by running `gpg --list-keys --with-subkey-fingerprints FC47DEE803DB612A`.
+
 Fetch and verify:
 
 ```bash


### PR DESCRIPTION
## Description

Adds a note to SECURITY.md clarifying that GitHub may display a signing subkey ID (e.g. `2BB500FE5A696562`) instead of the primary key ID (`FC47DEE803DB612A`). The subkey is mathematically linked to the primary key - this is standard GPG behavior, not a mismatch.

Closes #79

## Type of Change

- [ ] Bug fix (non-breaking)
- [ ] Feature (non-breaking)
- [ ] Breaking change
- [x] Documentation update

## Testing

- [x] `make test` passes (`go test -race -cover ./...`)
- [ ] New/changed code has corresponding test cases in `*_test.go`
- [ ] If OCI-calling code was changed, manual integration testing completed

**Test details:**
- Go version: N/A (docs-only change)
- Test environment: N/A

## Checklist

- [x] `make lint` passes
- [x] Self-review completed
- [ ] Comments added for complex logic
- [x] Documentation updated (CONTRIBUTING.md, README if needed)
- [ ] Tests added or updated for all new functionality
- [x] All CI checks pass