### PR TITLE
fix(docker): use BuildKit platform args for multi-platform builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,9 @@ RUN go mod download
 COPY . .
 
 ARG VERSION=dev
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
+ARG TARGETOS=linux
+ARG TARGETARCH=amd64
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
     go build \
     -ldflags "-s -w -X main.version=${VERSION}" \
     -o /bin/oci-sd-proxy \

--- a/deploy/kubernetes/charts/oci-prometheus-sd-proxy/Chart.yaml
+++ b/deploy/kubernetes/charts/oci-prometheus-sd-proxy/Chart.yaml
@@ -1,0 +1,19 @@
+apiVersion: v2
+name: oci-prometheus-sd-proxy
+description: Prometheus HTTP Service Discovery proxy for Oracle Cloud Infrastructure compute instances.
+type: application
+version: 0.1.0
+appVersion: "latest"
+home: https://github.com/amaanx86/oci-prometheus-sd-proxy
+sources:
+  - https://github.com/amaanx86/oci-prometheus-sd-proxy
+maintainers:
+  - name: Amaan Ul Haq Siddiqui
+    email: amaanulhaq.s@outlook.com
+    url: https://github.com/amaanx86
+keywords:
+  - prometheus
+  - service-discovery
+  - oci
+  - oracle-cloud
+  - monitoring

--- a/deploy/kubernetes/charts/oci-prometheus-sd-proxy/README.md
+++ b/deploy/kubernetes/charts/oci-prometheus-sd-proxy/README.md
@@ -1,0 +1,234 @@
+# oci-prometheus-sd-proxy Helm chart (MVP)
+
+Helm chart for [oci-prometheus-sd-proxy](https://github.com/amaanx86/oci-prometheus-sd-proxy): a Prometheus HTTP Service Discovery proxy for Oracle Cloud Infrastructure compute instances.
+
+This is an **MVP chart**. It deploys the proxy only. Operators supply OCI configuration and Secrets out-of-band.
+
+## What this chart installs
+
+- Deployment, Service (ClusterIP), ServiceAccount, and ConfigMap for `oci-prometheus-sd-proxy`
+- Non-sensitive `config.yaml` rendered from `.Values.config`
+- References to **existing** Kubernetes Secrets for `SERVER_TOKEN` and the OCI API private key
+- Basic pod/container `securityContext` and HTTP liveness/readiness probes
+
+## What this chart does not install or manage
+
+- Prometheus (or any scrape configuration inside Prometheus)
+- `node_exporter`, `windows_exporter`, or other instance agents
+- Kubernetes Secrets containing tokens or private keys
+- OCI IAM policies, dynamic groups, or network/firewall rules
+- [ServiceMonitor](https://github.com/prometheus-operator/prometheus-operator) (intentionally omitted from this MVP)
+- [ScrapeConfig](https://prometheus-operator.dev/docs/developer/scrapeconfig/) (possible later integration; out of scope here)
+- Chart publishing to GHCR or GitHub Pages
+- Helm chart release automation
+
+## Prerequisites
+
+- Kubernetes cluster with Helm 3
+- Network egress from the pod to OCI APIs for configured regions
+- OCI IAM permissions for the configured tenancy user (API key auth) or instance principal setup if you use that auth mode
+- Two **existing** Secrets (see below) created before or after install—the pod will not run until they exist
+- Replace placeholder OCIDs, regions, and fingerprints in `.Values.config` with your real non-secret OCI settings
+
+## Required existing Secrets
+
+The chart **does not** create Secrets. Configure names in `values.yaml` (`serverTokenSecret`, `ociPrivateKeySecret`).
+
+### SERVER_TOKEN Secret
+
+Used as the container env var `SERVER_TOKEN` (Bearer token for `GET /v1/targets`).
+
+Default reference: Secret `oci-sd-server-token`, key `server-token`.
+
+```bash
+# Generate a token locally (example)
+TOKEN="$(openssl rand -hex 32)"
+
+kubectl create secret generic oci-sd-server-token \
+  --namespace monitoring \
+  --from-literal=server-token="${TOKEN}"
+```
+
+Store the token securely; configure the same value in Prometheus separately (see below).
+
+### OCI private key Secret
+
+Mounted as a file at `{ociPrivateKeyMountPath}/{ociPrivateKeySecret.key}` (default: `/etc/oci-sd/keys/api_key.pem`).
+
+Default reference: Secret `oci-sd-oci-key`, key `api_key.pem`.
+
+```bash
+kubectl create secret generic oci-sd-oci-key \
+  --namespace monitoring \
+  --from-file=api_key.pem=/path/to/your/api_key.pem
+```
+
+**Important:** `config.tenancies[].private_key_path` must match the mounted file path. With defaults, use `/etc/oci-sd/keys/api_key.pem`.
+
+## Install
+
+Create Secrets in the target namespace, then install:
+
+```bash
+helm install oci-sd ./deploy/kubernetes/charts/oci-prometheus-sd-proxy \
+  --namespace monitoring \
+  --create-namespace
+```
+
+## Values override example
+
+Sensitive values must **not** go in `values.yaml`. Override Secret names and non-sensitive OCI config only:
+
+```yaml
+serverTokenSecret:
+  name: my-sd-token
+  key: server-token
+
+ociPrivateKeySecret:
+  name: my-oci-key
+  key: api_key.pem
+
+config:
+  server:
+    port: 8080
+  discovery:
+    tag_key: monitoring
+    tag_value: enabled
+    linux_port: 9100
+    windows_port: 9182
+    refresh_interval: 5m
+    rate_limit_rps: 10.0
+  tenancies:
+    - name: my-tenancy
+      auth_type: api_key
+      region: us-ashburn-1
+      tenancy_id: ocid1.tenancy.oc1..example
+      user_id: ocid1.user.oc1..example
+      fingerprint: "00:11:22:33:44:55:66:77:88:99:aa:bb:cc:dd:ee:ff"
+      private_key_path: /etc/oci-sd/keys/api_key.pem
+      compartments: []
+```
+
+Apply with:
+
+```bash
+helm install oci-sd ./deploy/kubernetes/charts/oci-prometheus-sd-proxy -f my-values.yaml -n monitoring
+```
+
+## config.yaml and CONFIG_PATH
+
+- `.Values.config` is rendered into a ConfigMap key `config.yaml`.
+- The Deployment sets `CONFIG_PATH` (default `/etc/oci-sd/config.yaml`) and mounts that file from the ConfigMap.
+- Do **not** put `server.token` or PEM key content in `.Values.config`.
+- Tenancies are YAML-only in the application; there are no env vars for tenancy blocks.
+
+## Health endpoints
+
+| Path | Auth | Notes |
+|------|------|-------|
+| `/healthz` | none | Liveness probe |
+| `/readyz` | none | Readiness probe; returns 200 today and does **not** check OCI discovery health |
+| `/v1/targets` | Bearer `SERVER_TOKEN` | Prometheus HTTP SD JSON |
+
+## Prometheus configuration (separate from this chart)
+
+Point Prometheus at the in-cluster Service with `http_sd_configs`. Token management in Prometheus is **your** responsibility; this chart does not configure Prometheus.
+
+Service DNS pattern: `<release-fullname>.<namespace>.svc:<port>` (default port `8080`).
+
+```yaml
+scrape_configs:
+  - job_name: oci-compute
+    http_sd_configs:
+      - url: http://oci-sd-oci-prometheus-sd-proxy.monitoring.svc:8080/v1/targets
+        authorization:
+          type: Bearer
+          credentials: <your-server-token>
+        refresh_interval: 60s
+    relabel_configs:
+      - source_labels: [__meta_oci_instance_name]
+        target_label: instance
+```
+
+Replace the URL host with your release fullname and namespace. Use a Prometheus Secret or external secret manager for `<your-server-token>`—not Helm values.
+
+## Using with kube-prometheus-stack
+
+This chart works with [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack). Install and configure kube-prometheus-stack **separately**—this chart deploys only `oci-prometheus-sd-proxy` and does not install Prometheus or configure scrape jobs for you.
+
+The proxy exposes Prometheus HTTP service discovery at:
+
+```text
+http://<release-fullname>.<namespace>.svc:8080/v1/targets
+```
+
+For a release named `oci-sd` in namespace `monitoring`, that is typically:
+
+```text
+http://oci-sd-oci-prometheus-sd-proxy.monitoring.svc:8080/v1/targets
+```
+
+**ServiceMonitor is intentionally not included.** This proxy is not a normal `/metrics` scrape target—it returns discovered OCI compute targets via HTTP SD. A ServiceMonitor would scrape the proxy itself rather than the instances the proxy discovers. [ScrapeConfig](https://prometheus-operator.dev/docs/developer/scrapeconfig/) support may be considered later but is not part of this MVP.
+
+Wire kube-prometheus-stack to the proxy using an **existing** additional scrape config Secret (managed outside this chart). Pin the kube-prometheus-stack chart version:
+
+```yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+helmCharts:
+  - name: kube-prometheus-stack
+    repo: https://prometheus-community.github.io/helm-charts
+    version: 72.6.2
+    releaseName: prometheus-stack
+    namespace: monitoring
+    valuesFile: helm-values.yaml
+    includeCRDs: true
+```
+
+In `helm-values.yaml`, enable the additional scrape config Secret reference:
+
+```yaml
+prometheus:
+  prometheusSpec:
+    additionalScrapeConfigsSecret:
+      enabled: true
+      name: prometheus-additional-scrape-configs
+      key: additional-scrape-configs.yaml
+```
+
+Create the Secret separately—do **not** commit tokens or scrape config files containing real credentials to Git:
+
+```bash
+kubectl create secret generic prometheus-additional-scrape-configs \
+  --namespace monitoring \
+  --from-file=additional-scrape-configs.yaml=/path/to/additional-scrape-configs.yaml
+```
+
+Example `additional-scrape-configs.yaml` (placeholder token only; use the same value as `SERVER_TOKEN` in the proxy Secret):
+
+```yaml
+- job_name: oci-compute
+  http_sd_configs:
+    - url: http://oci-sd-oci-prometheus-sd-proxy.monitoring.svc:8080/v1/targets
+      authorization:
+        type: Bearer
+        credentials: <your-server-token>
+      refresh_interval: 60s
+  relabel_configs:
+    - source_labels: [__meta_oci_instance_name]
+      target_label: instance
+```
+
+Store the Bearer token securely (e.g. sealed-secrets, external-secrets, or a local file excluded from version control). Replace the URL host with your release fullname and namespace.
+
+## Validation
+
+```bash
+helm lint deploy/kubernetes/charts/oci-prometheus-sd-proxy
+helm template oci-sd deploy/kubernetes/charts/oci-prometheus-sd-proxy --namespace monitoring
+```
+
+## Image
+
+Default image: `ghcr.io/amaanx86/oci-prometheus-sd-proxy:latest`. Pin a release tag or digest in production (`values.yaml` → `image.tag`).

--- a/deploy/kubernetes/charts/oci-prometheus-sd-proxy/templates/NOTES.txt
+++ b/deploy/kubernetes/charts/oci-prometheus-sd-proxy/templates/NOTES.txt
@@ -1,0 +1,20 @@
+OCI Prometheus SD Proxy (MVP) has been installed.
+
+Release:    {{ .Release.Name }}
+Namespace:  {{ .Release.Namespace }}
+
+In-cluster Service:
+  {{ include "oci-prometheus-sd-proxy.fullname" . }}.{{ .Release.Namespace }}.svc:{{ .Values.service.port }}
+
+Prometheus HTTP SD endpoint:
+  http://{{ include "oci-prometheus-sd-proxy.fullname" . }}.{{ .Release.Namespace }}.svc:{{ .Values.service.port }}/v1/targets
+  (requires Authorization: Bearer <SERVER_TOKEN>)
+
+Required existing Secrets (not created by this chart):
+  - {{ .Values.serverTokenSecret.name }} (key: {{ .Values.serverTokenSecret.key }}) → SERVER_TOKEN env var
+  - {{ .Values.ociPrivateKeySecret.name }} (key: {{ .Values.ociPrivateKeySecret.key }}) → mounted at {{ .Values.ociPrivateKeyMountPath }}/{{ .Values.ociPrivateKeySecret.key }}
+
+Configure Prometheus separately with http_sd_configs. This chart does not install Prometheus,
+node_exporter, or windows_exporter.
+
+ServiceMonitor and ScrapeConfig are not included in this MVP chart.

--- a/deploy/kubernetes/charts/oci-prometheus-sd-proxy/templates/_helpers.tpl
+++ b/deploy/kubernetes/charts/oci-prometheus-sd-proxy/templates/_helpers.tpl
@@ -1,0 +1,60 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "oci-prometheus-sd-proxy.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "oci-prometheus-sd-proxy.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Chart label value (chart name-version).
+*/}}
+{{- define "oci-prometheus-sd-proxy.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels applied to chart resources.
+*/}}
+{{- define "oci-prometheus-sd-proxy.labels" -}}
+helm.sh/chart: {{ include "oci-prometheus-sd-proxy.chart" . }}
+{{ include "oci-prometheus-sd-proxy.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels (stable across upgrades; used by Service and Deployment).
+*/}}
+{{- define "oci-prometheus-sd-proxy.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "oci-prometheus-sd-proxy.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+ServiceAccount name for use in later Deployment templates.
+*/}}
+{{- define "oci-prometheus-sd-proxy.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "oci-prometheus-sd-proxy.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/deploy/kubernetes/charts/oci-prometheus-sd-proxy/templates/configmap.yaml
+++ b/deploy/kubernetes/charts/oci-prometheus-sd-proxy/templates/configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "oci-prometheus-sd-proxy.fullname" . }}
+  labels:
+    {{- include "oci-prometheus-sd-proxy.labels" . | nindent 4 }}
+data:
+  config.yaml: |
+    {{- toYaml .Values.config | nindent 4 }}

--- a/deploy/kubernetes/charts/oci-prometheus-sd-proxy/templates/deployment.yaml
+++ b/deploy/kubernetes/charts/oci-prometheus-sd-proxy/templates/deployment.yaml
@@ -1,0 +1,65 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "oci-prometheus-sd-proxy.fullname" . }}
+  labels:
+    {{- include "oci-prometheus-sd-proxy.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "oci-prometheus-sd-proxy.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "oci-prometheus-sd-proxy.selectorLabels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "oci-prometheus-sd-proxy.serviceAccountName" . }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          env:
+            - name: CONFIG_PATH
+              value: {{ .Values.configPath | quote }}
+            - name: SERVER_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.serverTokenSecret.name | quote }}
+                  key: {{ .Values.serverTokenSecret.key | quote }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.containerPort }}
+              protocol: TCP
+          volumeMounts:
+            - name: config
+              mountPath: {{ .Values.configPath | quote }}
+              subPath: config.yaml
+              readOnly: true
+            - name: oci-private-key
+              mountPath: {{ printf "%s/%s" .Values.ociPrivateKeyMountPath .Values.ociPrivateKeySecret.key | quote }}
+              subPath: {{ .Values.ociPrivateKeySecret.key | quote }}
+              readOnly: true
+          {{- if .Values.livenessProbe.enabled }}
+          livenessProbe:
+            {{- omit .Values.livenessProbe "enabled" | toYaml | nindent 12 }}
+          {{- end }}
+          {{- if .Values.readinessProbe.enabled }}
+          readinessProbe:
+            {{- omit .Values.readinessProbe "enabled" | toYaml | nindent 12 }}
+          {{- end }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "oci-prometheus-sd-proxy.fullname" . }}
+        - name: oci-private-key
+          secret:
+            secretName: {{ .Values.ociPrivateKeySecret.name | quote }}

--- a/deploy/kubernetes/charts/oci-prometheus-sd-proxy/templates/service.yaml
+++ b/deploy/kubernetes/charts/oci-prometheus-sd-proxy/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "oci-prometheus-sd-proxy.fullname" . }}
+  labels:
+    {{- include "oci-prometheus-sd-proxy.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "oci-prometheus-sd-proxy.selectorLabels" . | nindent 4 }}

--- a/deploy/kubernetes/charts/oci-prometheus-sd-proxy/templates/serviceaccount.yaml
+++ b/deploy/kubernetes/charts/oci-prometheus-sd-proxy/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "oci-prometheus-sd-proxy.serviceAccountName" . }}
+  labels:
+    {{- include "oci-prometheus-sd-proxy.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/deploy/kubernetes/charts/oci-prometheus-sd-proxy/values.yaml
+++ b/deploy/kubernetes/charts/oci-prometheus-sd-proxy/values.yaml
@@ -1,0 +1,101 @@
+# Default values for oci-prometheus-sd-proxy.
+#
+# Sensitive values (SERVER_TOKEN, OCI API private keys) must NOT be placed here.
+# Create Kubernetes Secrets out-of-band and set serverTokenSecret / ociPrivateKeySecret names.
+
+replicaCount: 1
+
+image:
+  repository: ghcr.io/amaanx86/oci-prometheus-sd-proxy
+  # Documented quick-start tag; pin a release semver in production.
+  tag: latest
+  pullPolicy: IfNotPresent
+
+serviceAccount:
+  create: true
+  # When create is true and name is empty, the chart fullname is used.
+  name: ""
+  annotations: {}
+
+service:
+  type: ClusterIP
+  port: 8080
+
+# HTTP port the application listens on; keep config.server.port in sync when changed.
+containerPort: 8080
+
+# Path where config.yaml is mounted and passed to CONFIG_PATH.
+configPath: /etc/oci-sd/config.yaml
+
+# Existing Secret holding the bearer token for /v1/targets (SERVER_TOKEN).
+# Create before install, e.g. kubectl create secret generic oci-sd-server-token --from-literal=server-token=...
+serverTokenSecret:
+  name: oci-sd-server-token
+  key: server-token
+
+# Existing Secret holding the OCI API private key PEM file.
+# Create before install, e.g. kubectl create secret generic oci-sd-oci-key --from-file=api_key.pem=...
+ociPrivateKeySecret:
+  name: oci-sd-oci-key
+  key: api_key.pem
+
+# Base directory for the mounted key file; must align with config.tenancies[].private_key_path.
+ociPrivateKeyMountPath: /etc/oci-sd/keys
+
+podSecurityContext:
+  # Distroless nonroot image runs as UID 65532; omit runAsUser to use the image default.
+  runAsNonRoot: true
+
+# Container securityContext. Compatible with distroless nonroot and read-only mounts at /etc/oci-sd.
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  capabilities:
+    drop:
+      - ALL
+
+# HTTP probes use named port "http". Readiness checks /readyz only (not OCI discovery health).
+livenessProbe:
+  enabled: true
+  httpGet:
+    path: /healthz
+    port: http
+  initialDelaySeconds: 15
+  periodSeconds: 10
+  timeoutSeconds: 2
+  successThreshold: 1
+  failureThreshold: 3
+
+readinessProbe:
+  enabled: true
+  httpGet:
+    path: /readyz
+    port: http
+  initialDelaySeconds: 5
+  periodSeconds: 5
+  timeoutSeconds: 2
+  successThreshold: 1
+  failureThreshold: 3
+
+# Non-sensitive config.yaml content (rendered into a ConfigMap).
+# Do not put server.token or private key PEM content here.
+config:
+  server:
+    port: 8080
+  discovery:
+    tag_key: monitoring
+    tag_value: enabled
+    linux_port: 9100
+    windows_port: 9182
+    refresh_interval: 5m
+    rate_limit_rps: 10.0
+  tenancies:
+    - name: my-tenancy
+      auth_type: api_key
+      region: us-ashburn-1
+      tenancy_id: ocid1.tenancy.oc1..example
+      user_id: ocid1.user.oc1..example
+      fingerprint: "00:11:22:33:44:55:66:77:88:99:aa:bb:cc:dd:ee:ff"
+      private_key_path: /etc/oci-sd/keys/api_key.pem
+      compartments: []


### PR DESCRIPTION
## Description

The Dockerfile hardcoded `GOARCH=amd64` in the `go build` command. This means the ARM64 image variant published by the release workflow contained an AMD64 binary, causing an `exec format error` on ARM64 Kubernetes nodes before the process could even start.

This fix adds BuildKit's `TARGETOS` and `TARGETARCH` args and threads them into the build command. Both default to `linux/amd64` so a plain `docker build` still works. When `docker/build-push-action` builds for `linux/amd64,linux/arm64`, each platform now compiles its own correct binary.

Fixes #82

## Type of Change

- [x] Bug fix (non-breaking)
- [ ] Feature (non-breaking)
- [ ] Breaking change
- [ ] Documentation update

## Testing

- [x] `make test` passes (`go test -race -cover ./...`)
- [ ] New/changed code has corresponding test cases in `*_test.go`
- [ ] If OCI-calling code was changed, manual integration testing completed

**Test details:**
- Go version: 1.26.3
- Test environment: local

The change is build-time only - no application logic was touched, so no new test cases are needed. The fix will be verified end-to-end when the release workflow publishes the next multi-platform image.

## Checklist

- [x] `make lint` passes
- [x] Self-review completed
- [ ] Comments added for complex logic
- [x] Documentation updated (CONTRIBUTING.md, README if needed)
- [x] Tests added or updated for all new functionality
- [x] All CI checks pass