### PR TITLE
ci(helm): add release and publish workflow for ArtifactHub and GHCR

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -1,0 +1,71 @@
+name: Release and Publish Helm Chart
+
+on:
+  push:
+    tags:
+      - 'helm-v*'
+
+permissions:
+  contents: write
+  packages: write
+  pages: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.3
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4.3.0
+
+      - name: Validate chart
+        run: |
+          helm lint deploy/helm
+          helm template oci-sd deploy/helm > /dev/null
+
+      - name: Parse version
+        id: version
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/helm-v}
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Package chart
+        run: |
+          mkdir -p gh-pages
+          helm package deploy/helm --destination gh-pages/
+
+      - name: Generate Helm repo index
+        run: |
+          helm repo index gh-pages \
+            --url https://amaanx86.github.io/oci-prometheus-sd-proxy
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4.0.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./gh-pages
+          keep_files: true
+
+      - name: Login to GHCR
+        uses: docker/login-action@v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push chart to GHCR (OCI)
+        run: |
+          helm push gh-pages/oci-prometheus-sd-proxy-${{ steps.version.outputs.version }}.tgz \
+            oci://ghcr.io/amaanx86
+
+      - name: Upload chart to GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "${{ github.ref_name }}" \
+            gh-pages/oci-prometheus-sd-proxy-${{ steps.version.outputs.version }}.tgz \
+            --clobber

--- a/deploy/helm/.helmignore
+++ b/deploy/helm/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/


### PR DESCRIPTION
## Description

Implements automated Helm chart packaging, publishing, and release. Closes #89.

Triggered by `helm-v*` tags (consistent with the existing `v*` tag trigger on `docker-build-push.yml`) so chart releases are versioned independently from app releases.

## Type of Change

- [ ] Bug fix (non-breaking)
- [x] Feature (non-breaking)
- [ ] Breaking change
- [ ] Documentation update

## Changes

- `.github/workflows/helm-release.yml` - triggers on `helm-v*` tags; lints and templates the chart, packages it, publishes `index.yaml` to GitHub Pages, pushes the OCI artifact to `oci://ghcr.io/amaanx86`, and attaches the `.tgz` to the GitHub Release
- `deploy/helm/.helmignore` - standard ignore patterns so VCS dirs, editor files, and temp files are excluded from the packaged chart

## Testing

- [x] `make test` passes (`go test -race -cover ./...`)
- [x] New/changed code has corresponding test cases in `*_test.go`
- [ ] If OCI-calling code was changed, manual integration testing completed

**Test details:**
- `helm lint deploy/helm` passes
- `helm template oci-sd deploy/helm` renders cleanly
- Workflow not yet triggered end-to-end (requires GitHub Pages enabled on the repo and a `helm-v*` tag to fire)

## Checklist

- [x] `make lint` passes
- [x] `helm lint deploy/helm` passes
- [x] Self-review completed
- [ ] Comments added for complex logic
- [ ] Documentation updated (CONTRIBUTING.md, README if needed)
- [x] Tests added or updated for all new functionality
- [ ] All CI checks pass