### PR TITLE
chore(helm): promote chart to v1.0.0 stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # oci-prometheus-sd-proxy
 
+[![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/oci-prometheus-sd-proxy)](https://artifacthub.io/packages/search?repo=oci-prometheus-sd-proxy)
 [![GitHub Release](https://img.shields.io/github/v/release/amaanx86/oci-prometheus-sd-proxy)](https://github.com/amaanx86/oci-prometheus-sd-proxy/releases)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Go Report Card](https://goreportcard.com/badge/github.com/amaanx86/oci-prometheus-sd-proxy)](https://goreportcard.com/report/github.com/amaanx86/oci-prometheus-sd-proxy)
@@ -7,17 +8,26 @@
 [![SLSA 3](https://slsa.dev/images/gh-badge-level3.svg)](https://slsa.dev)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12388/badge)](https://www.bestpractices.dev/projects/12388)
 
-<img width="469" height="277" alt="OCI Prometheus SD Proxy" src="https://github.com/user-attachments/assets/333a7c32-93bd-4ad9-aea3-aea2d6a66a65" />
+![OCI Prometheus SD Proxy](https://github.com/user-attachments/assets/333a7c32-93bd-4ad9-aea3-aea2d6a66a65)
 
-A lightweight Go service that implements the [Prometheus HTTP Service Discovery](https://prometheus.io/docs/prometheus/latest/http_sd/) API for [Oracle Cloud Infrastructure](https://www.oracle.com/cloud/). It dynamically discovers compute instances across multiple OCI tenancies and compartments, filters them by tag, and returns their metadata in Prometheus-compatible HTTP SD format.
+A lightweight Go service that implements the
+[Prometheus HTTP Service Discovery](https://prometheus.io/docs/prometheus/latest/http_sd/) API
+for [Oracle Cloud Infrastructure](https://www.oracle.com/cloud/). It dynamically discovers
+compute instances across multiple OCI tenancies and compartments, filters them by tag, and
+returns their metadata in Prometheus-compatible HTTP SD format.
 
-> **Why HTTP SD over native OCI SD?** A native integration was proposed in [prometheus/prometheus#10226](https://github.com/prometheus/prometheus/issues/10226) but closed - Prometheus maintainers explicitly prefer HTTP SD to keep the binary lean. This approach also means independent releases, centralised caching across Prometheus replicas, and multi-tenancy without per-scrape-config workarounds.
+> **Why HTTP SD over native OCI SD?** A native integration was proposed in
+> [prometheus/prometheus#10226](https://github.com/prometheus/prometheus/issues/10226) but
+> closed - Prometheus maintainers explicitly prefer HTTP SD to keep the binary lean. This
+> approach also means independent releases, centralised caching across Prometheus replicas,
+> and multi-tenancy without per-scrape-config workarounds.
 
 ## Architecture
 
 ![oci-sd-proxy-arch](https://github.com/user-attachments/assets/a7d87901-1e67-4016-92b6-df66f5603b28)
 
-Multiple Prometheus replicas query the service discovery endpoint, which fetches instance data from multiple OCI tenancies in parallel and returns rich metadata for relabeling.
+Multiple Prometheus replicas query the service discovery endpoint, which fetches instance data
+from multiple OCI tenancies in parallel and returns rich metadata for relabeling.
 
 ## Quick Start
 
@@ -31,6 +41,29 @@ docker run -d \
   -p 8080:8080 \
   ghcr.io/amaanx86/oci-prometheus-sd-proxy:latest
 ```
+
+### Kubernetes (Helm)
+
+```bash
+# Create required secrets
+kubectl create secret generic oci-sd-server-token \
+  --namespace monitoring --create-namespace \
+  --from-literal=server-token="$(openssl rand -hex 32)"
+
+kubectl create secret generic oci-sd-oci-key \
+  --namespace monitoring \
+  --from-file=api_key.pem=~/.oci/api_key.pem
+
+# Install from GHCR
+helm install oci-sd-proxy \
+  oci://ghcr.io/amaanx86/oci-prometheus-sd-proxy \
+  --version 1.0.0-rc.2 \
+  --namespace monitoring \
+  --set image.tag=1.5.5 \
+  -f my-values.yaml
+```
+
+See [`deploy/helm/README.md`](deploy/helm/README.md) for the full values reference.
 
 ### Docker Compose
 
@@ -77,7 +110,7 @@ Two authentication methods are supported via `auth_type` in `config.yaml`.
 
 **API key auth** (default - works anywhere):
 
-```
+```text
 Allow group <group-name> to read instances in tenancy
 Allow group <group-name> to read compartments in tenancy
 Allow group <group-name> to read vnic-attachments in tenancy
@@ -87,7 +120,7 @@ Allow group <group-name> to read tag-namespaces in tenancy
 
 **Instance principal auth** (proxy runs on OCI compute - no credentials needed):
 
-```
+```text
 Allow dynamic-group <dynamic-group-name> to read instances in tenancy
 Allow dynamic-group <dynamic-group-name> to read compartments in tenancy
 Allow dynamic-group <dynamic-group-name> to read vnic-attachments in tenancy
@@ -95,11 +128,14 @@ Allow dynamic-group <dynamic-group-name> to read vnics in tenancy
 Allow dynamic-group <dynamic-group-name> to read tag-namespaces in tenancy
 ```
 
-These five permissions cover all API calls the proxy makes. Missing any will result in `NotAuthorizedOrNotFound` errors in the logs. See the [full installation docs](https://oci-prometheus-sd-proxy.readthedocs.io/) for dynamic group setup and policy scoping requirements.
+These five permissions cover all API calls the proxy makes. Missing any will result in
+`NotAuthorizedOrNotFound` errors in the logs. See the
+[full installation docs](https://oci-prometheus-sd-proxy.readthedocs.io/) for dynamic group
+setup and policy scoping requirements.
 
 ## Full Documentation
 
-Complete documentation available at: **https://oci-prometheus-sd-proxy.readthedocs.io/**
+Complete documentation available at: <https://oci-prometheus-sd-proxy.readthedocs.io/>
 
 - Installation & setup
 - Configuration reference
@@ -110,12 +146,13 @@ Complete documentation available at: **https://oci-prometheus-sd-proxy.readthedo
 
 ## Windows Instances - Port Selection
 
-The proxy needs to know whether an instance is Linux or Windows to pick the right exporter port:
+The proxy needs to know whether an instance is Linux or Windows to pick the right exporter
+port:
 
 | OS | Default Port | Exporter |
-|----|-------------|----------|
-| Linux | `9100` | [node_exporter](https://github.com/prometheus/node_exporter) |
-| Windows | `9182` | [windows_exporter](https://github.com/prometheus-community/windows_exporter) |
+| --- | --- | --- |
+| Linux | `9100` | [node\_exporter](https://github.com/prometheus/node_exporter) |
+| Windows | `9182` | [windows\_exporter](https://github.com/prometheus-community/windows_exporter) |
 
 **Detection order** (first match wins):
 
@@ -125,16 +162,23 @@ The proxy needs to know whether an instance is Linux or Windows to pick the righ
 
 **Recommended approach for Windows instances:**
 
-Set the freeform tag `os = windows` on the OCI instance, or make sure `win` appears in the VM display name.
+Set the freeform tag `os = windows` on the OCI instance, or make sure `win` appears in the VM
+display name.
 
-When installing `windows_exporter` via the MSI installer, configure it to listen on port `9182` (the default). If you prefer port `9100`, set that in the MSI installer and update `windows_port` in the proxy config to match - or simply leave both at their defaults and rely on the tag/name detection above.
+When installing `windows_exporter` via the MSI installer, configure it to listen on port
+`9182` (the default). If you prefer port `9100`, set that in the MSI installer and update
+`windows_port` in the proxy config to match - or simply leave both at their defaults and rely
+on the tag/name detection above.
 
-> **Note:** If a Windows VM has no `os` tag and no `win` in its name, the proxy will target it on port `9100`. In that case, either set the tag, rename the VM, or configure `windows_exporter` to listen on port `9100` during MSI installation.
+> **Note:** If a Windows VM has no `os` tag and no `win` in its name, the proxy will target
+> it on port `9100`. In that case, either set the tag, rename the VM, or configure
+> `windows_exporter` to listen on port `9100` during MSI installation.
 
 ## Features
 
 - **Multi-tenancy**: Discover instances across any number of OCI tenancies
-- **Optional tag-based filtering**: Filter by freeform/defined tag, or omit to discover all running instances
+- **Optional tag-based filtering**: Filter by freeform/defined tag, or omit to discover all
+  running instances
 - **Rich labels**: Tenancy, compartment, shape, region, all freeform tags, and all defined tags
 - **Fast discovery**: Parallel compartment scanning with caching
 - **Rate limiting**: Proactive token bucket + reactive retry policy prevent 429 errors
@@ -150,9 +194,9 @@ When installing `windows_exporter` via the MSI installer, configure it to listen
 ## Development
 
 ```bash
-make test  
-make lint   
-make build  
+make test
+make lint
+make build
 ```
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for the full workflow.
@@ -160,7 +204,8 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the full workflow.
 ## Maintainer
 
 **[Amaan Ul Haq Siddiqui](https://github.com/amaanx86)**
-- Email: amaanulhaq.s@outlook.com
+
+- Email: <amaanulhaq.s@outlook.com>
 - LinkedIn: [amaanulhaqsiddiqui](https://www.linkedin.com/in/amaanulhaqsiddiqui/)
 
 ## License

--- a/deploy/docker/README.md
+++ b/deploy/docker/README.md
@@ -1,9 +1,12 @@
 # OCI SD Proxy - Docker Compose for Docker Deployment
 
-[![Go Report Card](https://goreportcard.com/badge/github.com/amaanx86/oci-prometheus-sd-proxy)](https://goreportcard.com/report/github.com/amaanx86/oci-prometheus-sd-proxy)
+[![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/oci-prometheus-sd-proxy)](https://artifacthub.io/packages/search?repo=oci-prometheus-sd-proxy)
 [![GitHub Release](https://img.shields.io/github/v/release/amaanx86/oci-prometheus-sd-proxy)](https://github.com/amaanx86/oci-prometheus-sd-proxy/releases)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+[![Go Report Card](https://goreportcard.com/badge/github.com/amaanx86/oci-prometheus-sd-proxy)](https://goreportcard.com/report/github.com/amaanx86/oci-prometheus-sd-proxy)
 [![Docker Image](https://img.shields.io/badge/Docker-ghcr.io-blue?logo=docker)](https://github.com/amaanx86/oci-prometheus-sd-proxy/pkgs/container/oci-prometheus-sd-proxy)
+[![SLSA 3](https://slsa.dev/images/gh-badge-level3.svg)](https://slsa.dev)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12388/badge)](https://www.bestpractices.dev/projects/12388)
 
 Quick setup for running oci-prometheus-sd-proxy with Docker Compose.
 

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: oci-prometheus-sd-proxy
 description: Prometheus HTTP Service Discovery proxy for Oracle Cloud Infrastructure compute instances.
 type: application
-version: 1.0.0-rc.2
+version: 1.0.0
 appVersion: "1.5.5"
 home: https://github.com/amaanx86/oci-prometheus-sd-proxy
 sources:

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -4,13 +4,13 @@ description: Prometheus HTTP Service Discovery proxy for Oracle Cloud Infrastruc
 type: application
 version: 1.0.0-rc.2
 appVersion: "1.5.5"
-home: https://github.com/amaanax86/oci-prometheus-sd-proxy
+home: https://github.com/amaanx86/oci-prometheus-sd-proxy
 sources:
-  - https://github.com/amaanax86/oci-prometheus-sd-proxy
+  - https://github.com/amaanx86/oci-prometheus-sd-proxy
 maintainers:
   - name: Amaan Ul Haq Siddiqui
     email: amaanulhaq.s@outlook.com
-    url: https://github.com/amaanax86
+    url: https://github.com/amaanx86
 keywords:
   - prometheus
   - service-discovery

--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -1,11 +1,16 @@
-# OCI SD Proxy - Helm Chart for K8S Deployment
+# OCI SD Proxy - Helm Chart for Kubernetes Deployment
 
-[![Go Report Card](https://goreportcard.com/badge/github.com/amaanx86/oci-prometheus-sd-proxy)](https://goreportcard.com/report/github.com/amaanx86/oci-prometheus-sd-proxy)
+[![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/oci-prometheus-sd-proxy)](https://artifacthub.io/packages/search?repo=oci-prometheus-sd-proxy)
 [![GitHub Release](https://img.shields.io/github/v/release/amaanx86/oci-prometheus-sd-proxy)](https://github.com/amaanx86/oci-prometheus-sd-proxy/releases)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+[![Go Report Card](https://goreportcard.com/badge/github.com/amaanx86/oci-prometheus-sd-proxy)](https://goreportcard.com/report/github.com/amaanx86/oci-prometheus-sd-proxy)
 [![Docker Image](https://img.shields.io/badge/Docker-ghcr.io-blue?logo=docker)](https://github.com/amaanx86/oci-prometheus-sd-proxy/pkgs/container/oci-prometheus-sd-proxy)
+[![SLSA 3](https://slsa.dev/images/gh-badge-level3.svg)](https://slsa.dev)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12388/badge)](https://www.bestpractices.dev/projects/12388)
 
-Helm chart for [oci-prometheus-sd-proxy](https://github.com/amaanx86/oci-prometheus-sd-proxy) - a Prometheus HTTP Service Discovery proxy for Oracle Cloud Infrastructure compute instances.
+
+Helm chart for [oci-prometheus-sd-proxy](https://github.com/amaanx86/oci-prometheus-sd-proxy) -
+a Prometheus HTTP Service Discovery proxy for Oracle Cloud Infrastructure compute instances.
 
 ## Quick Start
 
@@ -26,7 +31,8 @@ kubectl create secret generic oci-sd-oci-key \
 
 ### 2. Configure OCI Settings
 
-Copy and edit `values.yaml`, filling in your real tenancy OCIDs, region, user, and fingerprint under `config.tenancies`. Do not put the private key or token here.
+Copy and edit `values.yaml`, filling in your real tenancy OCIDs, region, user, and fingerprint
+under `config.tenancies`. Do not put the private key or token here.
 
 ### 3. Install
 
@@ -72,7 +78,8 @@ curl -H "Authorization: Bearer ${TOKEN}" http://localhost:8080/v1/targets | jq .
 
 ### Option A - ScrapeConfig CRD (prometheus-operator >= 0.65, recommended)
 
-Reuses the same `serverTokenSecret` as the proxy - no credential duplication. Labels must match your `PrometheusSpec.scrapeConfigSelector`.
+Reuses the same `serverTokenSecret` as the proxy - no credential duplication.
+Labels must match your `PrometheusSpec.scrapeConfigSelector`.
 
 ```yaml
 scrapeConfig:
@@ -81,14 +88,16 @@ scrapeConfig:
     release: <your-prometheus-release-name>
 ```
 
-### Option B - http_sd_configs (standalone Prometheus or older operator)
+### Option B - http\_sd\_configs (standalone Prometheus or older operator)
 
-Point Prometheus at the in-cluster Service using `http_sd_configs`. Create the scrape config as a Secret and reference it via `additionalScrapeConfigsSecret`, or add it directly to `prometheus.yml`:
+Point Prometheus at the in-cluster Service using `http_sd_configs`. Create the scrape config
+as a Secret and reference it via `additionalScrapeConfigsSecret`, or add it directly to
+`prometheus.yml`:
 
 ```yaml
 - job_name: oci-compute
   http_sd_configs:
-    - url: http://oci-sd-oci-prometheus-sd-proxy.monitoring.svc:8080/v1/targets
+    - url: http://oci-sd-proxy-oci-prometheus-sd-proxy.monitoring.svc:8080/v1/targets
       authorization:
         type: Bearer
         credentials: <your-server-token>
@@ -106,9 +115,10 @@ Point Prometheus at the in-cluster Service using `http_sd_configs`. Create the s
 
 | Key | Default | Description |
 | --- | ------- | ----------- |
-| `replicaCount` | `1` | Replicas. Two is the practical maximum - more replicas multiply OCI API calls against the same rate limit. |
+| `replicaCount` | `1` | Number of replicas. Two is the practical maximum - more replicas multiply OCI API calls. |
+| `image.repository` | `ghcr.io/amaanx86/oci-prometheus-sd-proxy` | Image repository |
 | `image.tag` | `"latest"` | Image tag. Pin a semver in production. |
-| `image.pullPolicy` | `IfNotPresent` | Pull policy |
+| `image.pullPolicy` | `IfNotPresent` | Image pull policy |
 | `nameOverride` | `""` | Override chart name in resource names |
 | `fullnameOverride` | `""` | Override full resource name |
 | `imagePullSecrets` | `[]` | Pull secrets for private registries |
@@ -125,7 +135,7 @@ Point Prometheus at the in-cluster Service using `http_sd_configs`. Create the s
 | `serverTokenSecret.key` | `server-token` | Secret key for `SERVER_TOKEN` |
 | `ociPrivateKeySecret.enabled` | `true` | Mount OCI private key. Set `false` for `instance_principal` auth. |
 | `ociPrivateKeySecret.name` | `oci-sd-oci-key` | Secret name for OCI private key PEM |
-| `ociPrivateKeySecret.key` | `api_key.pem` | Secret key for OCI private key PEM |
+| `ociPrivateKeySecret.key` | `api_key.pem` | Secret key (filename) for OCI private key PEM |
 | `ociPrivateKeyMountPath` | `/etc/oci-sd/keys` | Directory where the key file is mounted |
 | `resources` | `{}` | CPU/memory requests and limits |
 | `livenessProbe.enabled` | `true` | Liveness probe on `/healthz` |
@@ -144,7 +154,7 @@ Point Prometheus at the in-cluster Service using `http_sd_configs`. Create the s
 | `extraVolumeMounts` | `[]` | Extra volume mounts |
 | `config` | see values.yaml | Non-sensitive `config.yaml` rendered into a ConfigMap |
 | `scrapeConfig.enabled` | `false` | Create a `ScrapeConfig` CRD (prometheus-operator >= 0.65) |
-| `scrapeConfig.labels` | `{}` | Labels added to the ScrapeConfig - must match `PrometheusSpec.scrapeConfigSelector` |
+| `scrapeConfig.labels` | `{}` | Labels to match `PrometheusSpec.scrapeConfigSelector` |
 | `scrapeConfig.jobName` | `oci-compute` | Prometheus job name |
 | `scrapeConfig.refreshInterval` | `60s` | Target list refresh interval |
 | `scrapeConfig.relabelings` | see values.yaml | Relabeling rules for `__meta_oci_*` labels |
@@ -163,8 +173,8 @@ deploy/helm/
     ├── deployment.yaml
     ├── service.yaml
     ├── serviceaccount.yaml
-    ├── pdb.yaml          # PodDisruptionBudget (disabled by default)
-    ├── scrapeconfig.yaml # ScrapeConfig CRD (disabled by default)
+    ├── pdb.yaml
+    ├── scrapeconfig.yaml
     └── NOTES.txt
 ```
 
@@ -185,12 +195,32 @@ helm template oci-sd deploy/helm --namespace monitoring
 
 ## Troubleshooting
 
-**Pod stuck in Pending**: The Secrets referenced by `serverTokenSecret` and `ociPrivateKeySecret` must exist before the pod starts. Create them first or disable `ociPrivateKeySecret.enabled` if using instance_principal auth.
+### Pod stuck in Pending
 
-**No targets returned**: Check that instances have the configured OCI tag (`config.discovery.tag_key` / `tag_value`). Omit both to discover all running instances. Verify the pod has network egress to OCI API endpoints for the configured regions.
+The Secrets referenced by `serverTokenSecret` and `ociPrivateKeySecret` must exist before the
+pod starts. Create them first or disable `ociPrivateKeySecret.enabled` if using
+`instance_principal` auth.
 
-**Auth failed on /v1/targets**: The `SERVER_TOKEN` in the Secret must match the `Authorization: Bearer <token>` header sent by Prometheus.
+### No targets returned
 
-**ScrapeConfig not picked up by Prometheus**: The labels on the ScrapeConfig must match `PrometheusSpec.scrapeConfigSelector`. Check with `kubectl get scrapeconfig -n monitoring`.
+Check that instances have the configured OCI tag (`config.discovery.tag_key` / `tag_value`).
+Omit both to discover all running instances. Verify the pod has network egress to OCI API
+endpoints for the configured regions.
 
-**Config changes not rolling out**: The Deployment uses a `checksum/config` annotation so it restarts automatically when the ConfigMap changes. If it doesn't, run `helm upgrade` to force a reconcile.
+### Auth failed on /v1/targets
+
+The `SERVER_TOKEN` in the Secret must match the `Authorization: Bearer <token>` header sent
+by Prometheus.
+
+### ScrapeConfig not picked up by Prometheus
+
+The labels on the ScrapeConfig must match `PrometheusSpec.scrapeConfigSelector`. Check with:
+
+```bash
+kubectl get scrapeconfig -n monitoring
+```
+
+### Config changes not rolling out
+
+The Deployment uses a `checksum/config` annotation so it restarts automatically when the
+ConfigMap changes. If it does not, run `helm upgrade` to force a reconcile.

--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -1,11 +1,11 @@
 # OCI SD Proxy - Helm Chart for K8S Deployment
 
-[![Go Report Card](https://goreportcard.com/badge/github.com/amaanax86/oci-prometheus-sd-proxy)](https://goreportcard.com/report/github.com/amaanax86/oci-prometheus-sd-proxy)
-[![GitHub Release](https://img.shields.io/github/v/release/amaanax86/oci-prometheus-sd-proxy)](https://github.com/amaanax86/oci-prometheus-sd-proxy/releases)
+[![Go Report Card](https://goreportcard.com/badge/github.com/amaanx86/oci-prometheus-sd-proxy)](https://goreportcard.com/report/github.com/amaanx86/oci-prometheus-sd-proxy)
+[![GitHub Release](https://img.shields.io/github/v/release/amaanx86/oci-prometheus-sd-proxy)](https://github.com/amaanx86/oci-prometheus-sd-proxy/releases)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![Docker Image](https://img.shields.io/badge/Docker-ghcr.io-blue?logo=docker)](https://github.com/amaanax86/oci-prometheus-sd-proxy/pkgs/container/oci-prometheus-sd-proxy)
+[![Docker Image](https://img.shields.io/badge/Docker-ghcr.io-blue?logo=docker)](https://github.com/amaanx86/oci-prometheus-sd-proxy/pkgs/container/oci-prometheus-sd-proxy)
 
-Helm chart for [oci-prometheus-sd-proxy](https://github.com/amaanax86/oci-prometheus-sd-proxy) - a Prometheus HTTP Service Discovery proxy for Oracle Cloud Infrastructure compute instances.
+Helm chart for [oci-prometheus-sd-proxy](https://github.com/amaanx86/oci-prometheus-sd-proxy) - a Prometheus HTTP Service Discovery proxy for Oracle Cloud Infrastructure compute instances.
 
 ## Quick Start
 
@@ -30,10 +30,27 @@ Copy and edit `values.yaml`, filling in your real tenancy OCIDs, region, user, a
 
 ### 3. Install
 
+Install directly from GHCR (recommended - no repo add needed):
+
 ```bash
-helm install oci-sd ./deploy/helm \
+helm install oci-sd-proxy \
+  oci://ghcr.io/amaanx86/oci-prometheus-sd-proxy \
+  --version <chart-version> \
   --namespace monitoring \
   --create-namespace \
+  --set image.tag=<app-version> \
+  -f my-values.yaml
+```
+
+Or install from the GitHub Pages Helm repo:
+
+```bash
+helm repo add oci-sd-proxy https://amaanx86.github.io/oci-prometheus-sd-proxy
+helm repo update
+helm install oci-sd-proxy oci-sd-proxy/oci-prometheus-sd-proxy \
+  --namespace monitoring \
+  --create-namespace \
+  --set image.tag=<app-version> \
   -f my-values.yaml
 ```
 
@@ -44,7 +61,7 @@ helm install oci-sd ./deploy/helm \
 kubectl get pods -n monitoring -l app.kubernetes.io/name=oci-prometheus-sd-proxy
 
 # Health check
-kubectl port-forward -n monitoring svc/oci-sd-oci-prometheus-sd-proxy 8080:8080
+kubectl port-forward -n monitoring svc/oci-sd-proxy-oci-prometheus-sd-proxy 8080:8080
 curl http://localhost:8080/healthz
 
 # Fetch targets

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -6,8 +6,8 @@
 replicaCount: 1
 
 image:
-  repository: ghcr.io/amaanax86/oci-prometheus-sd-proxy
-  # Documented quick-start tag; pin a release semver or digest in production.
+  repository: ghcr.io/amaanx86/oci-prometheus-sd-proxy
+  # Pin a release semver or digest in production; "latest" is provided for quick-start only.
   tag: "latest"
   pullPolicy: IfNotPresent
 
@@ -156,8 +156,9 @@ config:
   server:
     port: 8080
   discovery:
-    tag_key: monitoring
-    tag_value: enabled
+    # tag_key and tag_value are optional. Omit both to discover all running instances.
+    # tag_key: monitoring
+    # tag_value: enabled
     linux_port: 9100
     windows_port: 9182
     refresh_interval: 5m
@@ -165,11 +166,12 @@ config:
   tenancies:
     - name: my-tenancy
       auth_type: api_key
-      region: us-ashburn-1
+      region: me-jeddah-1
       tenancy_id: ocid1.tenancy.oc1..example
       user_id: ocid1.user.oc1..example
       fingerprint: "00:11:22:33:44:55:66:77:88:99:aa:bb:cc:dd:ee:ff"
       private_key_path: /etc/oci-sd/keys/api_key.pem
+      passphrase: ""
       compartments: []
 
 # ScrapeConfig CRD (monitoring.coreos.com/v1alpha1, prometheus-operator >= 0.65).

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -33,6 +33,104 @@ Simplest setup using Docker Compose:
 
     docker-compose -f docker-compose-production.yml up -d
 
+Kubernetes - Helm
+-----------------
+
+Install on any Kubernetes cluster using the published Helm chart.
+
+**Prerequisites:** ``kubectl`` and ``helm`` (v3.8+) configured against your cluster.
+
+**Step 1 - Create secrets**
+
+The pod requires two Kubernetes Secrets before it can start:
+
+.. code-block:: bash
+
+    # Bearer token for /v1/targets
+    TOKEN="$(openssl rand -hex 32)"
+    kubectl create secret generic oci-sd-server-token \
+      --namespace monitoring \
+      --from-literal=server-token="${TOKEN}"
+
+    # OCI API private key (skip if using instance_principal auth)
+    kubectl create secret generic oci-sd-oci-key \
+      --namespace monitoring \
+      --from-file=api_key.pem=~/.oci/api_key.pem
+
+**Step 2 - Prepare a values file**
+
+Create ``my-values.yaml`` with your tenancy details. Do not put the token or private key here:
+
+.. code-block:: yaml
+
+    image:
+      tag: "1.5.5"
+
+    config:
+      server:
+        port: 8080
+      discovery:
+        linux_port: 9100
+        windows_port: 9182
+        refresh_interval: 5m
+        rate_limit_rps: 10.0
+      tenancies:
+        - name: my-tenancy
+          auth_type: api_key
+          region: me-jeddah-1
+          tenancy_id: ocid1.tenancy.oc1..example
+          user_id: ocid1.user.oc1..example
+          fingerprint: "00:11:22:33:44:55:66:77:88:99:aa:bb:cc:dd:ee:ff"
+          private_key_path: /etc/oci-sd/keys/api_key.pem
+          passphrase: ""
+          compartments: []
+
+**Step 3 - Install**
+
+Install directly from GHCR (no repo add needed):
+
+.. code-block:: bash
+
+    helm install oci-sd-proxy \
+      oci://ghcr.io/amaanx86/oci-prometheus-sd-proxy \
+      --version 1.0.0 \
+      --namespace monitoring \
+      --create-namespace \
+      -f my-values.yaml
+
+Or install from the GitHub Pages Helm repository:
+
+.. code-block:: bash
+
+    helm repo add oci-sd-proxy https://amaanx86.github.io/oci-prometheus-sd-proxy
+    helm repo update
+    helm install oci-sd-proxy oci-sd-proxy/oci-prometheus-sd-proxy \
+      --namespace monitoring \
+      --create-namespace \
+      -f my-values.yaml
+
+**Step 4 - Verify**
+
+.. code-block:: bash
+
+    # Check pod is running
+    kubectl get pods -n monitoring -l app.kubernetes.io/name=oci-prometheus-sd-proxy
+
+    # Health check via port-forward
+    kubectl port-forward -n monitoring svc/oci-sd-proxy-oci-prometheus-sd-proxy 8080:8080
+    curl http://localhost:8080/healthz
+
+    # Fetch discovered targets
+    curl -H "Authorization: Bearer ${TOKEN}" http://localhost:8080/v1/targets | jq .
+
+.. note::
+
+   The in-cluster HTTP SD endpoint is:
+   ``http://oci-sd-proxy-oci-prometheus-sd-proxy.monitoring.svc:8080/v1/targets``
+
+   Point Prometheus at this URL using ``http_sd_configs``. See :doc:`prometheus-integration`
+   for the full scrape config example.
+
 Binary
 ------
 


### PR DESCRIPTION
## Description

Promotes the Helm chart from pre-release (`1.0.0-rc.2`) to stable `1.0.0`. Includes documentation improvements across the board.

Closes #93

Changes:
- `deploy/helm/Chart.yaml`: bump chart `version` from `1.0.0-rc.2` to `1.0.0`, fix all `amaanx86` username references
- `deploy/helm/values.yaml`: fix `image.repository` username, comment out `tag_key`/`tag_value` defaults (no-filter by default), add `passphrase` field to example tenancy
- `deploy/helm/README.md`: add ArtifactHub badge, fix markdown lint warnings, update install commands to use OCI registry path, fix port-forward service name
- `README.md`: add ArtifactHub badge, fix markdown lint warnings (MD033 inline HTML, MD040 code fence languages, MD009 trailing spaces, MD034 bare URLs), add Helm quick start section
- `docs/installation.rst`: add full Kubernetes/Helm installation section with secrets, values, install, and verify steps

## Type of Change

- [x] Documentation update

## Testing

- [x] `make test` passes (`go test -race -cover ./...`)
- [x] No Go code changed - documentation and chart metadata only
- [x] `helm lint deploy/helm` passes
- [x] `helm template` dry-run validated against live kind cluster

**Test details:**
- Chart installed via `helm install` from `oci://ghcr.io/amaanx86/oci-prometheus-sd-proxy:1.0.0-rc.2` on kind cluster (kind v0.31.0, k8s v1.35.0)
- Pod came up healthy, `/healthz` and `/v1/targets` responded correctly

## Checklist

- [x] `make lint` passes
- [x] Self-review completed
- [x] Documentation updated (README.md, deploy/helm/README.md, docs/installation.rst)
- [x] All CI checks pass